### PR TITLE
Add docker-compose file

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -2,7 +2,40 @@
 
 FROM node:alpine
 
-RUN apk --no-cache upgrade && apk add --no-cache imagemagick imagemagick-dev git msttcorefonts-installer python3 alpine-sdk
+RUN apk --no-cache upgrade
+RUN apk add --no-cache git msttcorefonts-installer python3 alpine-sdk ffmpeg \
+    zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev perl-dev \
+    ghostscript-dev libtool tiff-dev lcms2-dev libwebp-dev libxml2-dev libx11-dev \
+    libxext-dev chrpath libheif-dev pango-dev freetype fontconfig ghostscript \
+    ghostscript-fonts lcms2 graphviz
+
+# install imagemagick from source rather than using the package
+# since the alpine package does not include pango support.
+RUN git clone https://github.com/ImageMagick/ImageMagick.git ImageMagick \
+    && cd ImageMagick \
+    && git checkout 7.0.10-45 \
+    && ./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--enable-static \
+		--disable-openmp \
+		--with-threads \
+		--with-x \
+		--with-tiff \
+		--with-png \
+		--with-webp \
+		--with-gslib \
+		--with-gs-font-dir=/usr/share/fonts/Type1 \
+		--with-heic \
+		--with-modules \
+		--with-xml \
+		--with-perl \
+		--with-perl-options="PREFIX=/usr INSTALLDIRS=vendor" \
+		--with-pango \
+    && make \
+    && sudo make install
 
 RUN update-ms-fonts && fc-cache -f
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -41,8 +41,11 @@ RUN update-ms-fonts && fc-cache -f
 
 RUN adduser esmBot -s /bin/sh -D
 WORKDIR /home/esmBot/.internal
-COPY . .
+
+COPY ./package.json package.json
+COPY ./package-lock.json package-lock.json
 RUN npm install
+COPY . .
 RUN npm run build
 USER esmBot
 

--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -41,11 +41,11 @@ RUN update-ms-fonts && fc-cache -f
 
 RUN adduser esmBot -s /bin/sh -D
 WORKDIR /home/esmBot/.internal
-COPY . .
+COPY ./package.json package.json
+COPY ./package-lock.json package-lock.json
 RUN npm install
+COPY . .
 RUN npm run build
 USER esmBot
-
-# EXPOSE 3000
 
 ENTRYPOINT ["node", "app.js"]

--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -2,7 +2,40 @@
 
 FROM node:alpine
 
-RUN apk --no-cache upgrade && apk add --no-cache imagemagick imagemagick-dev git msttcorefonts-installer python3 alpine-sdk ffmpeg
+RUN apk --no-cache upgrade
+RUN apk add --no-cache git msttcorefonts-installer python3 alpine-sdk ffmpeg \
+    zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev perl-dev \
+    ghostscript-dev libtool tiff-dev lcms2-dev libwebp-dev libxml2-dev libx11-dev \
+    libxext-dev chrpath libheif-dev pango-dev freetype fontconfig ghostscript \
+    ghostscript-fonts lcms2 graphviz
+
+# install imagemagick from source rather than using the package
+# since the alpine package does not include pango support.
+RUN git clone https://github.com/ImageMagick/ImageMagick.git ImageMagick \
+    && cd ImageMagick \
+    && git checkout 7.0.10-45 \
+    && ./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--enable-static \
+		--disable-openmp \
+		--with-threads \
+		--with-x \
+		--with-tiff \
+		--with-png \
+		--with-webp \
+		--with-gslib \
+		--with-gs-font-dir=/usr/share/fonts/Type1 \
+		--with-heic \
+		--with-modules \
+		--with-xml \
+		--with-perl \
+		--with-perl-options="PREFIX=/usr INSTALLDIRS=vendor" \
+		--with-pango \
+    && make \
+    && sudo make install
 
 RUN update-ms-fonts && fc-cache -f
 

--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -1,0 +1,18 @@
+# Docker/Kubernetes file for running the bot
+
+FROM node:alpine
+
+RUN apk --no-cache upgrade && apk add --no-cache imagemagick imagemagick-dev git msttcorefonts-installer python3 alpine-sdk
+
+RUN update-ms-fonts && fc-cache -f
+
+RUN adduser esmBot -s /bin/sh -D
+WORKDIR /home/esmBot/.internal
+COPY . .
+RUN npm install
+RUN npm run build
+USER esmBot
+
+# EXPOSE 3000
+
+ENTRYPOINT ["node", "app.js"]

--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -2,7 +2,7 @@
 
 FROM node:alpine
 
-RUN apk --no-cache upgrade && apk add --no-cache imagemagick imagemagick-dev git msttcorefonts-installer python3 alpine-sdk
+RUN apk --no-cache upgrade && apk add --no-cache imagemagick imagemagick-dev git msttcorefonts-installer python3 alpine-sdk ffmpeg
 
 RUN update-ms-fonts && fc-cache -f
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     restart: unless-stopped
     volumes:
       - ./logs:/home/esmBot/.internal/logs
-      - ./servers.docker-compose.json:/home/esmBot/.internal/servers.json
       - bot-output:/home/esmBot/output
       - bot-temp:/home/esmBot/temp
     env_file:
@@ -42,8 +41,6 @@ services:
       dockerfile: Dockerfile.api
     image: esmbot-api
     restart: unless-stopped
-    volumes:
-      - ./servers.docker-compose.json:/home/esmBot/.internal/servers.json
     networks:
       esmbot:
         ipv4_address: 172.20.0.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,34 +8,55 @@ services:
     image: esmbot
     restart: unless-stopped
     volumes:
-    - ./logs:/home/esmBot/.internal/logs
-    - bot-output:/home/esmBot/output
-    - bot-temp:/home/esmBot/temp
+      - ./logs:/home/esmBot/.internal/logs
+      - ./servers.docker-compose.json:/home/esmBot/.internal/servers.json
+      - bot-output:/home/esmBot/output
+      - bot-temp:/home/esmBot/temp
     env_file:
       - .env
     environment:
       OUTPUT: /home/esmBot/help
       TEMPDIR: /home/esmBot/temp
+
+      MONGO: mongodb://mongo:27017/esmBot
+      # chrome remote debugger can only be accessed over localhost or IP
+      CHROME: 172.20.0.4:9222
     links:
       - lavalink
+      - chrome
     depends_on:
       - api
       - chrome
       - lavalink
       - mongo
 
+    networks:
+      esmbot:
+        ipv4_address: 172.20.0.2
+
+
   api:
+    container_name: api
     build:
       context: .
       dockerfile: Dockerfile.api
     image: esmbot-api
     restart: unless-stopped
+    volumes:
+      - ./servers.docker-compose.json:/home/esmBot/.internal/servers.json
+    networks:
+      esmbot:
+        ipv4_address: 172.20.0.3
 
   chrome:
+    container_name: chrome
     build:
       context: ./utils/screenshot
     image: headless-chrome-alpine
     restart: unless-stopped
+    networks:
+      esmbot:
+        ipv4_address: 172.20.0.4
 
   lavalink:
     container_name: lavalink
@@ -44,6 +65,9 @@ services:
     volumes:
       - ./application.yml:/opt/Lavalink/application.yml
       - ./assets:/opt/Lavalink/assets
+    networks:
+      esmbot:
+        ipv4_address: 172.20.0.5
 
   mongo:
     container_name: mongo
@@ -51,6 +75,9 @@ services:
     restart: unless-stopped
     volumes:
       - mongo-data:/data/db
+    networks:
+      esmbot:
+        ipv4_address: 172.20.0.6
 
   mongo-express:
     image: mongo-express
@@ -59,8 +86,19 @@ services:
       - mongo
     ports:
       - 8888:8081
+    networks:
+      esmbot:
+        ipv4_address: 172.20.0.7
 
 volumes:
   bot-output:
   bot-temp:
   mongo-data:
+
+networks:
+  esmbot:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24
+          gateway: 172.20.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+
+services:
+  bot:
+    build:
+      context: .
+      dockerfile: Dockerfile.bot
+    image: esmbot
+    restart: unless-stopped
+    volumes:
+    - ./logs:/home/esmBot/.internal/logs
+    env_file:
+      - .env
+    depends_on:
+      - api
+      - chrome
+      - lavalink
+      - mongo
+
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    image: esmbot-api
+    restart: unless-stopped
+
+  chrome:
+    build:
+      context: ./utils/screenshot
+    image: headless-chrome-alpine
+    restart: unless-stopped
+
+  lavalink:
+    container_name: lavalink
+    image: fredboat/lavalink:dev
+    restart: unless-stopped
+    volumes:
+      - ./application.yml:/opt/Lavalink/application.yml
+      - ./assets:/opt/Lavalink/assets
+
+  mongo:
+    container_name: mongo
+    image: mongo:latest
+    restart: unless-stopped
+    volumes:
+      - mongo-data:/data/db
+
+  mongo-express:
+    image: mongo-express
+    restart: unless-stopped
+    depends_on:
+      - mongo
+    ports:
+      - 8888:8081
+
+volumes:
+  mongo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,15 @@ services:
     restart: unless-stopped
     volumes:
     - ./logs:/home/esmBot/.internal/logs
+    - bot-output:/home/esmBot/output
+    - bot-temp:/home/esmBot/temp
     env_file:
       - .env
+    environment:
+      OUTPUT: /home/esmBot/help
+      TEMPDIR: /home/esmBot/temp
+    links:
+      - lavalink
     depends_on:
       - api
       - chrome
@@ -54,4 +61,6 @@ services:
       - 8888:8081
 
 volumes:
+  bot-output:
+  bot-temp:
   mongo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.0'
 
 services:
   bot:

--- a/servers.docker-compose.json
+++ b/servers.docker-compose.json
@@ -1,8 +1,0 @@
-{
-  "lava": [
-    { "id": "1", "host": "lavalink", "port": 2333, "password": "youshallnotpass" }
-  ],
-  "image": [
-    "api"
-  ]
-}

--- a/servers.docker-compose.json
+++ b/servers.docker-compose.json
@@ -1,0 +1,8 @@
+{
+  "lava": [
+    { "id": "1", "host": "lavalink", "port": 2333, "password": "youshallnotpass" }
+  ],
+  "image": [
+    "api"
+  ]
+}


### PR DESCRIPTION
This adds both a docker-compose file, and a Dockerfile for the bot itself, which allows for running the bot and all of its dependencies with a single command `docker-compose up -d`.

The compose script can probably be improved in a few places, but as it stands it all seems to work correctly. The only small thing that is currently required is that you must update the `MONGO` var in `.env` to the following:

```sh
MONGO=mongodb://mongo:27017/esmBot
```

The compose file also comes with `mongo-express`, which is a web client for interacting with MongoDB. This can be accessed from `localhost:8888`.

For lavalink and the image API to work, `servers.json` must be edited to update the hostnames:
```json
{
  "lava": [
    { "id": "1", "host": "lavalink", "port": 2333, "password": "youshallnotpass" }
  ],
  "image": [
    "api"
  ]
}
```