### PR TITLE
Ensure npm has access to package.json.

### DIFF
--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -47,8 +47,8 @@ COPY ./assets/caption2.ttf /home/esmBot/.font/caption2.ttf
 COPY ./assets/hbc.ttf /home/esmBot/.font/hbc.ttf
 RUN fc-cache -f
 
-COPY ./package.json package.json
-COPY ./package-lock.json package-lock.json
+COPY --chown=node:node ./package.json package.json
+COPY --chown=node:node ./package-lock.json package-lock.json
 RUN npm install
 COPY . .
 USER esmBot


### PR DESCRIPTION
This is a common issue, and I ran into it while installing esmBot. For me, and probably others npm throws a permissions error while building, and no packages will be installed. Simply chown the package.json to the node:node user, and this will work again.