### PR TITLE
Initialize cpuLoad to 0

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -21,7 +21,7 @@ const queue = [];
 
 if (isMainThread) {
   const { v4: uuidv4 } = require("uuid");
-  let cpuLoad;
+  let cpuLoad = 0;
 
   const getAverage = () => {
     const cpus = os.cpus();


### PR DESCRIPTION
Because the CPU load was only updated every 5 seconds, whenever you tried to use the API <5 seconds after starting the process, it would try to call `cpuLoad.toString` and error out because it was undefined. A bit of a weird edge case, but this should fix it.