### PR TITLE
Clean up image API code paths

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -110,11 +110,11 @@ const runJob = (job) => {
     }
 
     log(`Job ${job.uuid} started`, job.num);
-    const data = await run(object, true);
+    const {buffer, fileExtension} = await run(object);
 
     log(`Sending result of job ${job.uuid} back to the bot`, job.num);
     const server = net.createServer(function(tcpSocket) {
-      tcpSocket.write(Buffer.concat([Buffer.from(object.type || "image/png"), Buffer.from("\n"), data]), (err) => {
+      tcpSocket.write(Buffer.concat([Buffer.from(fileExtension), Buffer.from("\n"), buffer]), (err) => {
         if (err) console.error(err);
         tcpSocket.end(() => {
           server.close();

--- a/commands/freeze.js
+++ b/commands/freeze.js
@@ -11,7 +11,7 @@ exports.run = async (message) => {
     onlyGIF: true,
     type: image.type
   });
-  if (buffer === "nogif") return `${message.author.mention}, that isn't a GIF!`;
+  if (type === "nogif") return `${message.author.mention}, that isn't a GIF!`;
   return {
     file: buffer,
     name: `freeze.${type}`

--- a/commands/reverse.js
+++ b/commands/reverse.js
@@ -11,7 +11,7 @@ exports.run = async (message) => {
     onlyGIF: true,
     type: image.type
   });
-  if (buffer === "nogif") return `${message.author.mention}, that isn't a GIF!`;
+  if (type === "nogif") return `${message.author.mention}, that isn't a GIF!`;
   return {
     file: buffer,
     name: `reverse.${type}`

--- a/commands/slow.js
+++ b/commands/slow.js
@@ -11,7 +11,7 @@ exports.run = async (message) => {
     onlyGIF: true,
     type: image.type
   });
-  if (buffer === "nogif") return `${message.author.mention}, that isn't a GIF!`;
+  if (type === "nogif") return `${message.author.mention}, that isn't a GIF!`;
   return {
     file: buffer,
     name: `slow.${type}`

--- a/commands/soos.js
+++ b/commands/soos.js
@@ -12,7 +12,7 @@ exports.run = async (message) => {
     onlyGIF: true,
     type: image.type
   });
-  if (buffer === "nogif") return `${message.author.mention}, that isn't a GIF!`;
+  if (type === "nogif") return `${message.author.mention}, that isn't a GIF!`;
   return {
     file: buffer,
     name: `soos.${type}`

--- a/commands/speed.js
+++ b/commands/speed.js
@@ -10,7 +10,7 @@ exports.run = async (message) => {
     onlyGIF: true,
     type: image.type
   });
-  if (buffer === "nogif") return `${message.author.mention}, that isn't a GIF!`;
+  if (type === "nogif") return `${message.author.mention}, that isn't a GIF!`;
   return {
     file: buffer,
     name: `speed.${type}`

--- a/commands/unfreeze.js
+++ b/commands/unfreeze.js
@@ -11,7 +11,7 @@ exports.run = async (message) => {
     onlyGIF: true,
     type: image.type
   });
-  if (buffer === "nogif") return `${message.author.mention}, that isn't a GIF!`;
+  if (type === "nogif") return `${message.author.mention}, that isn't a GIF!`;
   return {
     file: buffer,
     name: `unfreeze.${type}`

--- a/utils/image-runner.js
+++ b/utils/image-runner.js
@@ -1,27 +1,26 @@
 const magick = require("../build/Release/image.node");
 const { promisify } = require("util");
-const { getType } = require("./image");
 const execPromise = promisify(require("child_process").exec);
 const { isMainThread, parentPort, workerData } = require("worker_threads");
 
 exports.run = async (object, fromAPI = false) => {
   return new Promise(async resolve => {
-    let type;
-    if (!fromAPI && object.path) {
-      const newType = (object.type ? object.type : await getType(object.path));
-      type = newType ? newType.split("/")[1] : "png";
-      if (type !== "gif" && object.onlyGIF) resolve({
+    // If the image has a path, it must also have a type
+    if (object.path) {
+      if (object.type !== "image/gif" && object.onlyGIF) resolve({
         buffer: "nogif",
         type: null
       });
-      object.type = type;
       const delay = (await execPromise(`ffprobe -v 0 -of csv=p=0 -select_streams v:0 -show_entries stream=r_frame_rate ${object.path}`)).stdout.replace("\n", "");
       object.delay = (100 / delay.split("/")[0]) * delay.split("/")[1];
     }
-    const data = await promisify(magick[object.cmd])(object);
+    // Convert from a MIME type (e.g. "image/png") to something ImageMagick understands (e.g. "png")
+    // Don't set `type` directly on the object we are passed as it will be read afterwards
+    const objectWithFixedType = Object.assign({}, object, {type: object.type.split("/")[1]});
+    const data = await promisify(magick[object.cmd])(objectWithFixedType);
     const returnObject = fromAPI ? data : {
       buffer: data,
-      type: type
+      type: object.type
     };
     resolve(returnObject);
   });

--- a/utils/image-runner.js
+++ b/utils/image-runner.js
@@ -8,8 +8,8 @@ exports.run = async object => {
     // If the image has a path, it must also have a type
     if (object.path) {
       if (object.type !== "image/gif" && object.onlyGIF) resolve({
-        buffer: "nogif",
-        type: null
+        buffer: Buffer.alloc(0),
+        fileExtension: "nogif"
       });
       const delay = (await execPromise(`ffprobe -v 0 -of csv=p=0 -select_streams v:0 -show_entries stream=r_frame_rate ${object.path}`)).stdout.replace("\n", "");
       object.delay = (100 / delay.split("/")[0]) * delay.split("/")[1];

--- a/utils/image-runner.js
+++ b/utils/image-runner.js
@@ -1,0 +1,41 @@
+const magick = require("../build/Release/image.node");
+const { promisify } = require("util");
+const { getType } = require("./image");
+const execPromise = promisify(require("child_process").exec);
+const { isMainThread, parentPort, workerData } = require("worker_threads");
+
+exports.run = async (object, fromAPI = false) => {
+  return new Promise(async resolve => {
+    let type;
+    if (!fromAPI && object.path) {
+      const newType = (object.type ? object.type : await getType(object.path));
+      type = newType ? newType.split("/")[1] : "png";
+      if (type !== "gif" && object.onlyGIF) resolve({
+        buffer: "nogif",
+        type: null
+      });
+      object.type = type;
+      const delay = (await execPromise(`ffprobe -v 0 -of csv=p=0 -select_streams v:0 -show_entries stream=r_frame_rate ${object.path}`)).stdout.replace("\n", "");
+      object.delay = (100 / delay.split("/")[0]) * delay.split("/")[1];
+    }
+    const data = await promisify(magick[object.cmd])(object);
+    const returnObject = fromAPI ? data : {
+      buffer: data,
+      type: type
+    };
+    resolve(returnObject);
+  });
+};
+
+if (!isMainThread) {
+  this.run(workerData)
+    // eslint-disable-next-line promise/always-return
+    .then(returnObject => {
+      parentPort.postMessage(returnObject);
+      process.exit();
+    })
+    .catch(err => {
+      // turn promise rejection into normal error
+      throw err;
+    });
+}

--- a/utils/image.js
+++ b/utils/image.js
@@ -133,16 +133,15 @@ exports.run = object => {
             });
             client.once("end", () => {
               const data = Buffer.concat(array);
-              // The response data is given as the MIME type of the image, followed by a newline, followed by the image
-              // data.
+              // The response data is given as the file extension/ImageMagick type of the image (e.g. "png"), followed
+              // by a newline, followed by the image data.
               const delimIndex = data.indexOf("\n");
               socket.close();
               if (delimIndex === -1) reject("Could not parse response");
               const payload = {
                 // Take just the image data
                 buffer: data.slice(delimIndex + 1),
-                // Convert MIME type (e.g. 'image/png') to image type (e.g. 'png'), later also used as a file extension
-                type: data.slice(0, delimIndex).toString().split("/")[1]
+                type: data.slice(0, delimIndex).toString()
               };
               resolve(payload);
             });
@@ -173,7 +172,7 @@ exports.run = object => {
       worker.on("message", (data) => {
         resolve({
           buffer: Buffer.from([...data.buffer]),
-          type: data.type
+          type: data.fileExtension
         });
       });
       worker.on("error", reject);


### PR DESCRIPTION
Most commits have individual descriptions, but at a high level I'm essentially getting rid of the complex mutually-recursing-across-processes behavior previously present in `image.js`. I've moved the part that actually calls into ImageMagick into its own file, so instead of commands calling `magick.run` which calls the image API which calls `magick.run` again (or `magick.run` calling itself in a worker thread if the image API is disabled), `magick.run` and the image API both delegate to the new "call ImageMagick" function.

I've also gotten rid of some duplicate code for handling GIFs, removed some dead code relating to image types (it can be re-added later in a much cleaner way if needed), and fixed a bug where GIF-only commands would throw an internal error instead of displaying the intended "that isn't a GIF!" message.