### PR TITLE
Update file-type dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "duckduckgo-images-api": "github:benpbolton/duckduckgo-images-api",
     "emoji-regex": "^8.0.0",
     "eris": "^0.13.4",
-    "file-type": "^13.1.2",
+    "file-type": "^16.1.0",
     "jsqr": "^1.3.1",
     "lavacord": "^1.1.9",
     "moment": "^2.29.1",


### PR DESCRIPTION
Resolves #50.

Old versions of the `file-type` package seem to only read the first 1024 bytes of a file. This means it'll fail to recognize PNGs with the `IDAT` chunk after the first 1024 bytes. This was fixed in later versions of `file-type`, so update to the lastest one.