### PR TITLE
Image command abstraction (proof of concept)

### DIFF
--- a/commands/9gag.js
+++ b/commands/9gag.js
@@ -1,22 +1,14 @@
-const magick = require("../utils/image.js");
+const makeImageCommand = require("../utils/image-command.js");
 
-exports.run = async (message) => {
-  message.channel.sendTyping();
-  const image = await require("../utils/imagedetect.js")(message);
-  if (image === undefined) return `${message.author.mention}, you need to provide an image to add a 9GAG watermark!`;
-  const { buffer, type } = await magick.run({
-    cmd: "watermark",
-    path: image.path,
+module.exports = makeImageCommand({
+  commandName: "9gag",
+  aliases: ["ninegag", "gag"],
+  help: "Adds the 9gag watermark to an image",
+  requiresImage: true,
+  noImageGivenMessage: "you need to provide an image to add a 9GAG watermark!",
+  magickCommand: "watermark",
+  params: {
     water: "./assets/images/9gag.png",
-    gravity: 6,
-    type: image.type
-  });
-  return {
-    file: buffer,
-    name: `9gag.${type}`
-  };
-};
-
-exports.aliases = ["ninegag", "gag"];
-exports.category = 5;
-exports.help = "Adds the 9gag watermark to an image";
+    gravity: 6
+  }
+});

--- a/utils/image-command.js
+++ b/utils/image-command.js
@@ -1,0 +1,60 @@
+const magick = require("./image.js");
+const imagedetect = require("./imagedetect.js");
+
+/**
+ * Generate a command that outputs an image through the ImageMagick API.
+ * @param {object} args Arguments
+ * @param {string} args.commandName The name of this command.
+ * @param {string[]} [args.aliases] Aliases of this command.
+ * @param {string} args.help This command's help string.
+ * @param {boolean} [args.requiresImage=false] True if this command operates on an input image. False by default.
+ * @param {boolean} [args.requiresText=false] True if this command requires text to be given. False by default.
+ * @param {string} [args.noImageGivenMessage] If `requiresImage` is true, this is the error message that will be
+ * displayed to the user if no input image is given.
+ * @param {string} [args.noTextGivenMessage] If `requiresText` is true, this is the error message that will be
+ * displayed to the user if no input text is given.
+ * @param {string} args.magickCommand The name of the ImageMagick command to run.
+ * @param {(object|function)} args.params Additional parameters to be passed to the ImageMagick function. This can also
+ * be a function which will be called with the command arguments and should return additional parameters as an object.
+ */
+const makeImageCommand = args => {
+  return {
+    run: async (message, cmdArgs) => {
+      message.channel.sendTyping();
+      const magickParams = {
+        cmd: args.magickCommand
+      };
+
+      if (args.requiresImage) {
+        const image = await imagedetect(message);
+        if (image === undefined) return `${message.author.mention}, ${args.noImageGivenMessage}`;
+        magickParams.path = image.path;
+        magickParams.type = image.type;
+      }
+
+      if (args.requiresText) {
+        if (cmdArgs.length === 0) return `${message.author.mention}, ${args.noTextGivenMessage}`;
+      }
+
+      switch (typeof args.params) {
+        case "function":
+          Object.assign(magickParams, args.makeParams(cmdArgs));
+          break;
+        case "object":
+          Object.assign(magickParams, args.params);
+          break;
+      }
+
+      const { buffer, type } = await magick.run(magickParams);
+      return {
+        file: buffer,
+        name: `${args.commandName}.${type}`
+      };
+    },
+    aliases: args.aliases,
+    category: 5,
+    help: args.help
+  };
+};
+
+module.exports = makeImageCommand;


### PR DESCRIPTION
This PR attempts to move the common image-command code (running `imagedetect`, sending a typing indicator, uploading embeds) into a common function, which should make it possible to change the way image commands behave without having to copy-paste the same change into the code for every single image command. This will hopefully make it easier to do things like rate limiting.

So far, I've only done this for the `9gag` command, to gauge whether this change is something you want before I put lots of time into porting every single image command.