### PR TITLE
Rate-limit commands

### DIFF
--- a/utils/collections.js
+++ b/utils/collections.js
@@ -1,6 +1,7 @@
 exports.commands = new Map();
 exports.aliases = new Map();
 exports.info = new Map();
+exports.runningCommands = new Set();
 
 class Cache extends Map {
   constructor(values) {


### PR DESCRIPTION
This implements a basic form of rate limiting that will prevent queueing of multiple commands with the same arguments and command name in the same channel. Note that the user running the command is not taken into account.

Currently this applies to all commands--should it apply only to image commands?

This does have some limitations--for one, because this is implemented within the event handler and not the commands themselves, there's no way to tell if (for image commands) the target image is the same between command invocations. My other PR would be necessary to implement something like that.