### PR TITLE
Stop using ffprobe to read GIF frame delay

### DIFF
--- a/natives/blur.cc
+++ b/natives/blur.cc
@@ -51,7 +51,7 @@ Napi::Value Blur(const Napi::CallbackInfo &info)
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   bool sharp = obj.Get("sharp").As<Napi::Boolean>().Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   BlurWorker* blurWorker = new BlurWorker(cb, path, sharp, type, delay);
   blurWorker->Queue();

--- a/natives/blurple.cc
+++ b/natives/blurple.cc
@@ -49,7 +49,7 @@ Napi::Value Blurple(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   BlurpleWorker* blurpleWorker = new BlurpleWorker(cb, path, type, delay);
   blurpleWorker->Queue();

--- a/natives/caption.cc
+++ b/natives/caption.cc
@@ -40,11 +40,11 @@ class CaptionWorker : public Napi::AsyncWorker {
       appendImages(&appended, images.begin(), images.end(), true);
       appended.repage();
       appended.magick(type);
+      appended.animationDelay(delay == 0 ? image.animationDelay() : delay);
       captioned.push_back(appended);
     }
 
     optimizeImageLayers(&result, captioned.begin(), captioned.end());
-    if (delay != 0) for_each(result.begin(), result.end(), animationDelayImage(delay));
     writeImages(result.begin(), result.end(), &blob);
   }
 

--- a/natives/caption.cc
+++ b/natives/caption.cc
@@ -67,7 +67,7 @@ Napi::Value Caption(const Napi::CallbackInfo &info)
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string caption = obj.Get("caption").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   CaptionWorker* captionWorker = new CaptionWorker(cb, caption, path, type, delay);
   captionWorker->Queue();

--- a/natives/caption2.cc
+++ b/natives/caption2.cc
@@ -66,7 +66,7 @@ Napi::Value CaptionTwo(const Napi::CallbackInfo &info)
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string caption = obj.Get("caption").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   CaptionTwoWorker* captionTwoWorker = new CaptionTwoWorker(cb, caption, path, type, delay);
   captionTwoWorker->Queue();

--- a/natives/caption2.cc
+++ b/natives/caption2.cc
@@ -39,11 +39,11 @@ class CaptionTwoWorker : public Napi::AsyncWorker {
       appendImages(&appended, images.begin(), images.end(), true);
       appended.repage();
       appended.magick(type);
+      appended.animationDelay(delay == 0 ? image.animationDelay() : delay);
       captioned.push_back(appended);
     }
 
     optimizeImageLayers(&result, captioned.begin(), captioned.end());
-    if (delay != 0) for_each(result.begin(), result.end(), animationDelayImage(delay));
     writeImages(result.begin(), result.end(), &blob);
   }
 

--- a/natives/circle.cc
+++ b/natives/circle.cc
@@ -48,7 +48,7 @@ Napi::Value Circle(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   CircleWorker* circleWorker = new CircleWorker(cb, path, type, delay);
   circleWorker->Queue();

--- a/natives/crop.cc
+++ b/natives/crop.cc
@@ -49,7 +49,7 @@ Napi::Value Crop(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   CropWorker* blurWorker = new CropWorker(cb, path, type, delay);
   blurWorker->Queue();

--- a/natives/explode.cc
+++ b/natives/explode.cc
@@ -49,7 +49,7 @@ Napi::Value Explode(const Napi::CallbackInfo &info)
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   int amount = obj.Get("amount").As<Napi::Number>().Int32Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   ExplodeWorker* explodeWorker = new ExplodeWorker(cb, path, amount, type, delay);
   explodeWorker->Queue();

--- a/natives/flag.cc
+++ b/natives/flag.cc
@@ -55,7 +55,7 @@ Napi::Value Flag(const Napi::CallbackInfo &info)
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string overlay = obj.Get("overlay").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   FlagWorker* flagWorker = new FlagWorker(cb, path, overlay, type, delay);
   flagWorker->Queue();

--- a/natives/flip.cc
+++ b/natives/flip.cc
@@ -50,7 +50,7 @@ Napi::Value Flip(const Napi::CallbackInfo &info)
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   bool flop = obj.Has("flop") ? obj.Get("flop").As<Napi::Boolean>().Value() : false;
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   FlipWorker* flipWorker = new FlipWorker(cb, path, flop, type, delay);
   flipWorker->Queue();

--- a/natives/freeze.cc
+++ b/natives/freeze.cc
@@ -42,7 +42,7 @@ Napi::Value Freeze(const Napi::CallbackInfo &info)
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   bool loop = obj.Has("loop") ? obj.Get("loop").As<Napi::Boolean>().Value() : false;
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   FreezeWorker* blurWorker = new FreezeWorker(cb, path, loop, type, delay);
   blurWorker->Queue();

--- a/natives/gamexplain.cc
+++ b/natives/gamexplain.cc
@@ -53,7 +53,7 @@ Napi::Value Gamexplain(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   GamexplainWorker* blurWorker = new GamexplainWorker(cb, path, type, delay);
   blurWorker->Queue();

--- a/natives/globe.cc
+++ b/natives/globe.cc
@@ -70,7 +70,7 @@ Napi::Value Globe(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   GlobeWorker* blurWorker = new GlobeWorker(cb, path, type, delay);
   blurWorker->Queue();

--- a/natives/invert.cc
+++ b/natives/invert.cc
@@ -50,7 +50,7 @@ Napi::Value Invert(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   InvertWorker* invertWorker = new InvertWorker(cb, path, type, delay);
   invertWorker->Queue();

--- a/natives/leak.cc
+++ b/natives/leak.cc
@@ -52,7 +52,7 @@ Napi::Value Leak(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   LeakWorker* blurWorker = new LeakWorker(cb, path, type, delay);
   blurWorker->Queue();

--- a/natives/magik.cc
+++ b/natives/magik.cc
@@ -50,7 +50,7 @@ Napi::Value Magik(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
 
   MagikWorker* explodeWorker = new MagikWorker(cb, path, type, delay);

--- a/natives/meme.cc
+++ b/natives/meme.cc
@@ -80,7 +80,7 @@ Napi::Value Meme(const Napi::CallbackInfo &info)
   string top = obj.Get("top").As<Napi::String>().Utf8Value();
   string bottom = obj.Get("bottom").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   MemeWorker* blurWorker = new MemeWorker(cb, path, top, bottom, type, delay);
   blurWorker->Queue();

--- a/natives/mirror.cc
+++ b/natives/mirror.cc
@@ -49,11 +49,11 @@ class MirrorWorker : public Napi::AsyncWorker {
       appendImages(&final, mirrored.begin(), mirrored.end(), vertical);
       final.repage();
       final.magick(type);
+      final.animationDelay(delay == 0 ? image.animationDelay() : delay);
       mid.push_back(final);
     }
 
     optimizeImageLayers(&result, mid.begin(), mid.end());
-    if (delay != 0) for_each(result.begin(), result.end(), animationDelayImage(delay));
     writeImages(result.begin(), result.end(), &blob);
   }
 

--- a/natives/mirror.cc
+++ b/natives/mirror.cc
@@ -78,7 +78,7 @@ Napi::Value Mirror(const Napi::CallbackInfo &info)
   bool vertical = obj.Has("vertical") ? obj.Get("vertical").As<Napi::Boolean>().Value() : false;
   bool first = obj.Has("first") ? obj.Get("first").As<Napi::Boolean>().Value() : false;
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   MirrorWorker* mirrorWorker = new MirrorWorker(cb, path, vertical, first, type, delay);
   mirrorWorker->Queue();

--- a/natives/misc.cc
+++ b/natives/misc.cc
@@ -48,7 +48,7 @@ Napi::Value Swirl(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   SwirlWorker* flopWorker = new SwirlWorker(cb, path, type, delay);
   flopWorker->Queue();

--- a/natives/motivate.cc
+++ b/natives/motivate.cc
@@ -56,11 +56,11 @@ class MotivateWorker : public Napi::AsyncWorker {
       appendImages(&final, to_append.begin(), to_append.end(), true);
       final.repage();
       final.magick(type);
+      final.animationDelay(delay == 0 ? image.animationDelay() : delay);
       mid.push_back(final);
     }
 
     optimizeImageLayers(&result, mid.begin(), mid.end());
-    if (delay != 0) for_each(result.begin(), result.end(), animationDelayImage(delay));
     writeImages(result.begin(), result.end(), &blob);
   }
 

--- a/natives/motivate.cc
+++ b/natives/motivate.cc
@@ -84,7 +84,7 @@ Napi::Value Motivate(const Napi::CallbackInfo &info)
   string top = obj.Get("top").As<Napi::String>().Utf8Value();
   string bottom = obj.Get("bottom").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   MotivateWorker* blurWorker = new MotivateWorker(cb, path, top, bottom, type, delay);
   blurWorker->Queue();

--- a/natives/resize.cc
+++ b/natives/resize.cc
@@ -58,7 +58,7 @@ Napi::Value Resize(const Napi::CallbackInfo &info)
   bool stretch = obj.Has("stretch") ? obj.Get("stretch").As<Napi::Boolean>().Value() : false;
   bool wide = obj.Has("wide") ? obj.Get("wide").As<Napi::Boolean>().Value() : false;
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   ResizeWorker* explodeWorker = new ResizeWorker(cb, path, stretch, wide, type, delay);
   explodeWorker->Queue();

--- a/natives/reverse.cc
+++ b/natives/reverse.cc
@@ -52,7 +52,7 @@ Napi::Value Reverse(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   bool soos = obj.Has("soos") ? obj.Get("soos").As<Napi::Boolean>().Value() : false;
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   ReverseWorker* explodeWorker = new ReverseWorker(cb, path, soos, delay);
   explodeWorker->Queue();

--- a/natives/scott.cc
+++ b/natives/scott.cc
@@ -31,11 +31,11 @@ class ScottWorker : public Napi::AsyncWorker {
       image.extent(Geometry("864x481"), Magick::CenterGravity);
       watermark_new.composite(image, Geometry("-110+83"), Magick::OverCompositeOp);
       watermark_new.magick(type);
+      watermark_new.animationDelay(delay == 0 ? image.animationDelay() : delay);
       mid.push_back(watermark_new);
     }
 
     optimizeImageLayers(&result, mid.begin(), mid.end());
-    if (delay != 0) for_each(result.begin(), result.end(), animationDelayImage(delay));
     writeImages(result.begin(), result.end(), &blob);
   }
 

--- a/natives/scott.cc
+++ b/natives/scott.cc
@@ -57,7 +57,7 @@ Napi::Value Scott(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   ScottWorker* blurWorker = new ScottWorker(cb, path, type, delay);
   blurWorker->Queue();

--- a/natives/speed.cc
+++ b/natives/speed.cc
@@ -62,7 +62,7 @@ Napi::Value Speed(const Napi::CallbackInfo &info)
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   bool slow = obj.Has("slow") ? obj.Get("slow").As<Napi::Boolean>().Value() : false;
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   SpeedWorker* explodeWorker = new SpeedWorker(cb, path, slow, type, delay);
   explodeWorker->Queue();

--- a/natives/speed.cc
+++ b/natives/speed.cc
@@ -14,10 +14,23 @@ class SpeedWorker : public Napi::AsyncWorker {
   void Execute() {
     list <Image> frames;
     readImages(&frames, in_path);
-    
-    int new_delay = slow ? delay * 2 : delay / 2;
+
+    int old_delay = 0;
+    // if passed a delay, use that. otherwise use the average frame delay.
+    // GIFs can have a variable framerate, and the frameskipping logic here doesn't handle that.
+    // TODO: revisit?
+    if (delay == 0) {
+      for (Image &image : frames) {
+        old_delay += image.animationDelay();
+      }
+      old_delay /= frames.size();
+    } else {
+      old_delay = delay;
+    }
+
+    int new_delay = slow ? old_delay * 2 : old_delay / 2;
     if (new_delay <= 1) {
-      new_delay = delay;
+      new_delay = old_delay;
       auto it = frames.begin();
       while(it != frames.end() && ++it != frames.end()) it = frames.erase(it);
     } else {

--- a/natives/spin.cc
+++ b/natives/spin.cc
@@ -64,7 +64,7 @@ Napi::Value Spin(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   SpinWorker* blurWorker = new SpinWorker(cb, path, type, delay);
   blurWorker->Queue();

--- a/natives/tile.cc
+++ b/natives/tile.cc
@@ -36,11 +36,11 @@ class TileWorker : public Napi::AsyncWorker {
       appendImages(&frame, montage.begin(), montage.end(), true);
       frame.repage();
       frame.scale(Geometry("800x800>"));
+      frame.animationDelay(delay == 0 ? image.animationDelay() : delay);
       mid.push_back(frame);
     }
 
     optimizeImageLayers(&result, mid.begin(), mid.end());
-    if (delay != 0) for_each(result.begin(), result.end(), animationDelayImage(delay));
     writeImages(result.begin(), result.end(), &blob);
   }
 

--- a/natives/tile.cc
+++ b/natives/tile.cc
@@ -62,7 +62,7 @@ Napi::Value Tile(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   TileWorker* flopWorker = new TileWorker(cb, path, type, delay);
   flopWorker->Queue();

--- a/natives/trump.cc
+++ b/natives/trump.cc
@@ -31,11 +31,11 @@ class TrumpWorker : public Napi::AsyncWorker {
       image.extent(Geometry("800x450"), Magick::CenterGravity);
       watermark_new.composite(image, Geometry("-25+134"), Magick::DstOverCompositeOp);
       watermark_new.magick(type);
+      watermark_new.animationDelay(delay == 0 ? image.animationDelay() : delay);
       mid.push_back(watermark_new);
     }
 
     optimizeImageLayers(&result, mid.begin(), mid.end());
-    if (delay != 0) for_each(result.begin(), result.end(), animationDelayImage(delay));
     writeImages(result.begin(), result.end(), &blob);
   }
 

--- a/natives/trump.cc
+++ b/natives/trump.cc
@@ -57,7 +57,7 @@ Napi::Value Trump(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   TrumpWorker* blurWorker = new TrumpWorker(cb, path, type, delay);
   blurWorker->Queue();

--- a/natives/wall.cc
+++ b/natives/wall.cc
@@ -55,7 +55,7 @@ Napi::Value Wall(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   WallWorker* flopWorker = new WallWorker(cb, path, type, delay);
   flopWorker->Queue();

--- a/natives/watermark.cc
+++ b/natives/watermark.cc
@@ -79,7 +79,7 @@ Napi::Value Watermark(const Napi::CallbackInfo &info)
   bool append = obj.Has("append") ? obj.Get("append").As<Napi::Boolean>().Value() : false;
   bool mc = obj.Has("mc") ? obj.Get("mc").As<Napi::Boolean>().Value() : false;
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   WatermarkWorker* watermarkWorker = new WatermarkWorker(cb, path, water, gravity, type, delay, resize, append, mc);
   watermarkWorker->Queue();

--- a/natives/watermark.cc
+++ b/natives/watermark.cc
@@ -47,11 +47,11 @@ class WatermarkWorker : public Napi::AsyncWorker {
         final = image;
       }
       image.magick(type);
+      final.animationDelay(delay == 0 ? image.animationDelay() : delay);
       mid.push_back(final);
     }
 
     optimizeImageLayers(&result, mid.begin(), mid.end());
-    if (delay != 0) for_each(result.begin(), result.end(), animationDelayImage(delay));
     writeImages(result.begin(), result.end(), &blob);
   }
 

--- a/natives/wdt.cc
+++ b/natives/wdt.cc
@@ -52,7 +52,7 @@ Napi::Value Wdt(const Napi::CallbackInfo &info)
   Napi::Function cb = info[1].As<Napi::Function>();
   string path = obj.Get("path").As<Napi::String>().Utf8Value();
   string type = obj.Get("type").As<Napi::String>().Utf8Value();
-  int delay = obj.Get("delay").As<Napi::Number>().Int32Value();
+  int delay = obj.Has("delay") ? obj.Get("delay").As<Napi::Number>().Int32Value() : 0;
 
   WdtWorker* blurWorker = new WdtWorker(cb, path, type, delay);
   blurWorker->Queue();

--- a/natives/wdt.cc
+++ b/natives/wdt.cc
@@ -26,11 +26,11 @@ class WdtWorker : public Napi::AsyncWorker {
       image.scale(Geometry("374x374>"));
       watermark_new.composite(image, Magick::CenterGravity, Magick::OverCompositeOp);
       watermark_new.magick(type);
+      watermark_new.animationDelay(delay == 0 ? image.animationDelay() : delay);
       mid.push_back(watermark_new);
     }
 
     optimizeImageLayers(&result, mid.begin(), mid.end());
-    if (delay != 0) for_each(result.begin(), result.end(), animationDelayImage(delay));
     writeImages(result.begin(), result.end(), &blob);
   }
 

--- a/utils/image-runner.js
+++ b/utils/image-runner.js
@@ -1,6 +1,5 @@
 const magick = require("../build/Release/image.node");
 const { promisify } = require("util");
-const execPromise = promisify(require("child_process").exec);
 const { isMainThread, parentPort, workerData } = require("worker_threads");
 
 exports.run = async object => {
@@ -11,8 +10,7 @@ exports.run = async object => {
         buffer: Buffer.alloc(0),
         fileExtension: "nogif"
       });
-      const delay = (await execPromise(`ffprobe -v 0 -of csv=p=0 -select_streams v:0 -show_entries stream=r_frame_rate ${object.path}`)).stdout.replace("\n", "");
-      object.delay = (100 / delay.split("/")[0]) * delay.split("/")[1];
+      object.delay = 0;
     }
     // Convert from a MIME type (e.g. "image/png") to something ImageMagick understands (e.g. "png").
     // Don't set `type` directly on the object we are passed as it will be read afterwards.

--- a/utils/image-runner.js
+++ b/utils/image-runner.js
@@ -10,7 +10,6 @@ exports.run = async object => {
         buffer: Buffer.alloc(0),
         fileExtension: "nogif"
       });
-      object.delay = 0;
     }
     // Convert from a MIME type (e.g. "image/png") to something ImageMagick understands (e.g. "png").
     // Don't set `type` directly on the object we are passed as it will be read afterwards.


### PR DESCRIPTION
In my testing, this roughly doubles the GIF processing speed by only having to download the image once.

I've left the C++ code for handling a passed-in delay intact, but if you're not planning to reuse it in the future then it should probably be removed (in another PR).