### PR TITLE
Pass `sock` in recursive `acceptJob` calls

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -32,14 +32,14 @@ const acceptJob = async (uuid, sock) => {
     }, sock);
     jobAmount--;
     if (queue.length > 0) {
-      acceptJob(queue[0]);
+      acceptJob(queue[0], sock);
     }
     log(`Job ${uuid} has finished`);
   } catch (err) {
     console.error(`Error on job ${uuid}:`, err);
     jobAmount--;
     if (queue.length > 0) {
-      acceptJob(queue[0]);
+      acceptJob(queue[0], sock);
     }
     delete jobs[uuid];
     sock.write(Buffer.concat([Buffer.from([0x2]), Buffer.from(uuid), Buffer.from(err.toString())]));


### PR DESCRIPTION
Without passing `sock`, whenever a job errors out, line 45 (`sock.write(Buffer.concat([Buffer.from([0x2]), Buffer.from(uuid), Buffer.from(err.toString())]));`) will error out and cause the entire API process to exit because `sock` is undefined.