### PR TITLE
Make image operations on GIFs faster by changing dithering methods

### DIFF
--- a/natives/blur.cc
+++ b/natives/blur.cc
@@ -26,7 +26,15 @@ class BlurWorker : public Napi::AsyncWorker {
     for_each(coalesced.begin(), coalesced.end(), magickImage(type));
 
     optimizeTransparency(coalesced.begin(), coalesced.end());
-    if (delay != 0) for_each(coalesced.begin(), coalesced.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : coalesced) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(coalesced.begin(), coalesced.end(), &blob);
   }
 

--- a/natives/blurple.cc
+++ b/natives/blurple.cc
@@ -27,6 +27,15 @@ class BlurpleWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(blurpled.begin(), blurpled.end());
+
+    if (type == "gif") {
+      for (Image &image : blurpled) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+      }
+    }
+    
+
     writeImages(blurpled.begin(), blurpled.end(), &blob);
   }
 

--- a/natives/caption.cc
+++ b/natives/caption.cc
@@ -45,6 +45,15 @@ class CaptionWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(captioned.begin(), captioned.end());
+
+    if (type == "gif") {
+      for (Image &image : captioned) {
+        image.quantizeDither(false);
+        image.quantize();
+      }
+    }
+    
+
     writeImages(captioned.begin(), captioned.end(), &blob);
   }
 

--- a/natives/caption2.cc
+++ b/natives/caption2.cc
@@ -43,6 +43,14 @@ class CaptionTwoWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(captioned.begin(), captioned.end());
+
+    if (type == "gif") {
+      for (Image &image : captioned) {
+        image.quantizeDither(false);
+        image.quantize();
+      }
+    }
+
     writeImages(captioned.begin(), captioned.end(), &blob);
   }
 

--- a/natives/circle.cc
+++ b/natives/circle.cc
@@ -25,7 +25,15 @@ class CircleWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(blurred.begin(), blurred.end());
-    if (delay != 0) for_each(blurred.begin(), blurred.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : blurred) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(blurred.begin(), blurred.end(), &blob);
   }
 

--- a/natives/crop.cc
+++ b/natives/crop.cc
@@ -26,7 +26,15 @@ class CropWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
-    if (delay != 0) for_each(mid.begin(), mid.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/explode.cc
+++ b/natives/explode.cc
@@ -25,7 +25,15 @@ class ExplodeWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(blurred.begin(), blurred.end());
-    if (delay != 0) for_each(blurred.begin(), blurred.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : blurred) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(blurred.begin(), blurred.end(), &blob);
   }
 

--- a/natives/flag.cc
+++ b/natives/flag.cc
@@ -31,7 +31,15 @@ class FlagWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
-    if (delay != 0) for_each(mid.begin(), mid.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/flip.cc
+++ b/natives/flip.cc
@@ -25,7 +25,15 @@ class FlipWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
-    if (delay != 0) for_each(mid.begin(), mid.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/gamexplain.cc
+++ b/natives/gamexplain.cc
@@ -30,7 +30,15 @@ class GamexplainWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
-    if (delay != 0) for_each(mid.begin(), mid.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/globe.cc
+++ b/natives/globe.cc
@@ -48,6 +48,12 @@ class GlobeWorker : public Napi::AsyncWorker {
     } else if (type != "GIF") {
       for_each(mid.begin(), mid.end(), animationDelayImage(5));
     }
+
+    for (Image &image : mid) {
+      image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+      image.quantize();
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/invert.cc
+++ b/natives/invert.cc
@@ -27,7 +27,15 @@ class InvertWorker : public Napi::AsyncWorker {
     for_each(mid.begin(), mid.end(), magickImage(type));
 
     optimizeTransparency(mid.begin(), mid.end());
-    if (delay != 0) for_each(mid.begin(), mid.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/leak.cc
+++ b/natives/leak.cc
@@ -31,7 +31,15 @@ class LeakWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
-    if (delay != 0) for_each(mid.begin(), mid.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/magik.cc
+++ b/natives/magik.cc
@@ -27,7 +27,15 @@ class MagikWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(blurred.begin(), blurred.end());
-    if (delay != 0) for_each(blurred.begin(), blurred.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : blurred) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(blurred.begin(), blurred.end(), &blob);
   }
 

--- a/natives/meme.cc
+++ b/natives/meme.cc
@@ -57,7 +57,15 @@ class MemeWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
-    if (delay != 0) for_each(mid.begin(), mid.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/mirror.cc
+++ b/natives/mirror.cc
@@ -53,6 +53,15 @@ class MirrorWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/misc.cc
+++ b/natives/misc.cc
@@ -25,7 +25,15 @@ class SwirlWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
-    if (delay != 0) for_each(mid.begin(), mid.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/motivate.cc
+++ b/natives/motivate.cc
@@ -60,6 +60,15 @@ class MotivateWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/resize.cc
+++ b/natives/resize.cc
@@ -32,7 +32,15 @@ class ResizeWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(blurred.begin(), blurred.end());
-    if (delay != 0) for_each(blurred.begin(), blurred.end(), animationDelayImage(delay));
+    
+    if (type == "gif") {
+      for (Image &image : blurred) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(blurred.begin(), blurred.end(), &blob);
   }
 

--- a/natives/reverse.cc
+++ b/natives/reverse.cc
@@ -28,7 +28,15 @@ class ReverseWorker : public Napi::AsyncWorker {
     for_each(coalesced.begin(), coalesced.end(), magickImage("GIF"));
 
     optimizeTransparency(coalesced.begin(), coalesced.end());
-    if (delay != 0) for_each(coalesced.begin(), coalesced.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : coalesced) {
+        image.quantizeDither(false);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(coalesced.begin(), coalesced.end(), &blob);
   }
 

--- a/natives/scott.cc
+++ b/natives/scott.cc
@@ -35,6 +35,15 @@ class ScottWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/spin.cc
+++ b/natives/spin.cc
@@ -42,6 +42,12 @@ class SpinWorker : public Napi::AsyncWorker {
     } else if (type != "GIF") {
       for_each(mid.begin(), mid.end(), animationDelayImage(5));
     }
+
+    for (Image &image : mid) {
+      image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+      image.quantize();
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/tile.cc
+++ b/natives/tile.cc
@@ -40,6 +40,15 @@ class TileWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/trump.cc
+++ b/natives/trump.cc
@@ -35,6 +35,15 @@ class TrumpWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/wall.cc
+++ b/natives/wall.cc
@@ -32,7 +32,15 @@ class WallWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
-    if (delay != 0) for_each(mid.begin(), mid.end(), animationDelayImage(delay));
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/watermark.cc
+++ b/natives/watermark.cc
@@ -51,6 +51,15 @@ class WatermarkWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 

--- a/natives/wdt.cc
+++ b/natives/wdt.cc
@@ -30,6 +30,15 @@ class WdtWorker : public Napi::AsyncWorker {
     }
 
     optimizeTransparency(mid.begin(), mid.end());
+
+    if (type == "gif") {
+      for (Image &image : mid) {
+        image.quantizeDitherMethod(FloydSteinbergDitherMethod);
+        image.quantize();
+        if (delay != 0) image.animationDelay(delay);
+      }
+    }
+
     writeImages(mid.begin(), mid.end(), &blob);
   }
 


### PR DESCRIPTION
This changes image operations to use either Floyd-Steinberg dithering or no dithering, depending on whether I think the specific operation needed to dither the output.

The default ImageMagick dithering algorithm (Riemersma dithering) is quite slow, and took up the majority of processing time for image operations. Floyd-Steinberg dithering is roughly twice as fast, and no dithering is three times as fast. This should therefore speed up image processing by quite a bit.