### PR TITLE
Fix flag command erroring out when no flag is provided

### DIFF
--- a/commands/flag.js
+++ b/commands/flag.js
@@ -7,7 +7,7 @@ exports.run = async (message, args) => {
   message.channel.sendTyping();
   const image = await require("../utils/imagedetect.js")(message);
   if (image === undefined) return `${message.author.mention}, you need to provide an image to overlay a flag onto!`;
-  if (!args[0].match(emojiRegex)) return `${message.author.mention}, you need to provide an emoji of a flag to overlay!`;
+  if (args.length === 0 || !args[0].match(emojiRegex)) return `${message.author.mention}, you need to provide an emoji of a flag to overlay!`;
   const flag = emoji.unemojify(args[0]).replaceAll(":", "").replace("flag-", "");
   let path = `./assets/images/region-flags/png/${flag.toUpperCase()}.png`;
   if (flag === "🏴‍☠️") path = "./assets/images/pirateflag.png";


### PR DESCRIPTION
Now it'll gracefully handle the error instead of returning an internal error log.