### PR TITLE
Remove redundant animationDelay calls

### DIFF
--- a/natives/mirror.cc
+++ b/natives/mirror.cc
@@ -58,7 +58,6 @@ class MirrorWorker : public Napi::AsyncWorker {
       for (Image &image : mid) {
         image.quantizeDither(false);
         image.quantize();
-        if (delay != 0) image.animationDelay(delay);
       }
     }
 

--- a/natives/motivate.cc
+++ b/natives/motivate.cc
@@ -65,7 +65,6 @@ class MotivateWorker : public Napi::AsyncWorker {
       for (Image &image : mid) {
         image.quantizeDither(false);
         image.quantize();
-        if (delay != 0) image.animationDelay(delay);
       }
     }
 

--- a/natives/scott.cc
+++ b/natives/scott.cc
@@ -40,7 +40,6 @@ class ScottWorker : public Napi::AsyncWorker {
       for (Image &image : mid) {
         image.quantizeDitherMethod(FloydSteinbergDitherMethod);
         image.quantize();
-        if (delay != 0) image.animationDelay(delay);
       }
     }
 

--- a/natives/tile.cc
+++ b/natives/tile.cc
@@ -45,7 +45,6 @@ class TileWorker : public Napi::AsyncWorker {
       for (Image &image : mid) {
         image.quantizeDitherMethod(FloydSteinbergDitherMethod);
         image.quantize();
-        if (delay != 0) image.animationDelay(delay);
       }
     }
 

--- a/natives/trump.cc
+++ b/natives/trump.cc
@@ -40,7 +40,6 @@ class TrumpWorker : public Napi::AsyncWorker {
       for (Image &image : mid) {
         image.quantizeDitherMethod(FloydSteinbergDitherMethod);
         image.quantize();
-        if (delay != 0) image.animationDelay(delay);
       }
     }
 

--- a/natives/watermark.cc
+++ b/natives/watermark.cc
@@ -56,7 +56,6 @@ class WatermarkWorker : public Napi::AsyncWorker {
       for (Image &image : mid) {
         image.quantizeDitherMethod(FloydSteinbergDitherMethod);
         image.quantize();
-        if (delay != 0) image.animationDelay(delay);
       }
     }
 

--- a/natives/wdt.cc
+++ b/natives/wdt.cc
@@ -35,7 +35,6 @@ class WdtWorker : public Napi::AsyncWorker {
       for (Image &image : mid) {
         image.quantizeDitherMethod(FloydSteinbergDitherMethod);
         image.quantize();
-        if (delay != 0) image.animationDelay(delay);
       }
     }
 


### PR DESCRIPTION
I got a bit too enthusiastic with the Ctrl+C Ctrl+V and accidentally added these `animationDelay` calls in commands where it was already being called in an earlier step.

This is mostly a code cleanliness thing but it may have broken variable-framerate GIFs, which this should fix.