### PR TITLE
Make processing emoji an environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ PREFIX=&
 # Optional
 ###########
 
+# Put the emoji for processing messages here
+# Example:
+# PROCESSING_EMOJI=<a:processing:818243325891051581>
+PROCESSING_EMOJI=
+
 # Put Cat API token here
 CAT=
 # Put Mashape/RapidAPI key here

--- a/commands/caption.js
+++ b/commands/caption.js
@@ -5,7 +5,7 @@ exports.run = async (message, args) => {
   if (image === undefined) return `${message.author.mention}, you need to provide an image/GIF to add a caption!`;
   const newArgs = args.filter(item => !item.includes(image.url) );
   if (args.length === 0) return `${message.author.mention}, you need to provide some text to add a caption!`;
-  const processMessage = await message.channel.createMessage("<a:processing:479351417102925854> Processing... This might take a while");
+  const processMessage = await message.channel.createMessage(`${process.env.PROCESSING_EMOJI || "<a:processing:479351417102925854>"} Processing... This might take a while`);
   const { buffer, type } = await magick.run({
     cmd: "caption",
     path: image.path,

--- a/commands/caption2.js
+++ b/commands/caption2.js
@@ -5,7 +5,7 @@ exports.run = async (message, args) => {
   const image = await require("../utils/imagedetect.js")(message);
   if (image === undefined) return `${message.author.mention}, you need to provide an image/GIF to add a caption!`;
   const newArgs = args.filter(item => !item.includes(image.url) );
-  const processMessage = await message.channel.createMessage("<a:processing:479351417102925854> Processing... This might take a while");
+  const processMessage = await message.channel.createMessage(`${process.env.PROCESSING_EMOJI || "<a:processing:479351417102925854>"} Processing... This might take a while`);
   const { buffer, type } = await magick.run({
     cmd: "captionTwo",
     path: image.path,

--- a/commands/globe.js
+++ b/commands/globe.js
@@ -3,7 +3,7 @@ const magick = require("../utils/image.js");
 exports.run = async (message) => {
   const image = await require("../utils/imagedetect.js")(message);
   if (image === undefined) return `${message.author.mention}, you need to provide an image to spin!`;
-  const processMessage = await message.channel.createMessage("<a:processing:479351417102925854> Processing... This might take a while");
+  const processMessage = await message.channel.createMessage(`${process.env.PROCESSING_EMOJI || "<a:processing:479351417102925854>"} Processing... This might take a while`);
   const { buffer } = await magick.run({
     cmd: "globe",
     path: image.path,

--- a/commands/magik.js
+++ b/commands/magik.js
@@ -3,7 +3,7 @@ const magick = require("../utils/image.js");
 exports.run = async (message) => {
   const image = await require("../utils/imagedetect.js")(message);
   if (image === undefined) return `${message.author.mention}, you need to provide an image to add some magik!`;
-  const processMessage = await message.channel.createMessage("<a:processing:479351417102925854> Processing... This might take a while");
+  const processMessage = await message.channel.createMessage(`${process.env.PROCESSING_EMOJI || "<a:processing:479351417102925854>"} Processing... This might take a while`);
   const { buffer, type } = await magick.run({
     cmd: "magik",
     path: image.path,

--- a/commands/motivate.js
+++ b/commands/motivate.js
@@ -5,7 +5,7 @@ exports.run = async (message, args) => {
   if (image === undefined) return `${message.author.mention}, you need to provide an image/GIF to make a motivational poster!`;
   const newArgs = args.filter(item => !item.includes(image.url) );
   if (args.length === 0) return `${message.author.mention}, you need to provide some text to make a motivational poster!`;
-  const processMessage = await message.channel.createMessage("<a:processing:479351417102925854> Processing... This might take a while");
+  const processMessage = await message.channel.createMessage(`${process.env.PROCESSING_EMOJI || "<a:processing:479351417102925854>"} Processing... This might take a while`);
   const [topText, bottomText] = newArgs.join(" ").split(/(?<!\\),/).map(elem => elem.trim());
   const { buffer, type } = await magick.run({
     cmd: "motivate",

--- a/commands/spin.js
+++ b/commands/spin.js
@@ -3,7 +3,7 @@ const magick = require("../utils/image.js");
 exports.run = async (message) => {
   const image = await require("../utils/imagedetect.js")(message);
   if (image === undefined) return `${message.author.mention}, you need to provide an image to spin!`;
-  const processMessage = await message.channel.createMessage("<a:processing:479351417102925854> Processing... This might take a while");
+  const processMessage = await message.channel.createMessage(`${process.env.PROCESSING_EMOJI || "<a:processing:479351417102925854>"} Processing... This might take a while`);
   const { buffer } = await magick.run({
     cmd: "spin",
     path: image.path,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "esmbot",
       "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
@@ -999,7 +1000,6 @@
     "node_modules/erlpack": {
       "version": "0.1.3",
       "resolved": "git+ssh://git@github.com/abalabahaha/erlpack.git#5d0064f9e106841e1eead711a6451f99b0d289fd",
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "esmbot",
       "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
@@ -1000,6 +999,7 @@
     "node_modules/erlpack": {
       "version": "0.1.3",
       "resolved": "git+ssh://git@github.com/abalabahaha/erlpack.git#5d0064f9e106841e1eead711a6451f99b0d289fd",
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {


### PR DESCRIPTION
Instead of self-hosters being stuck with Discord showing `:processing:` before all processing messages, give them the option of setting the emoji themselves with environment variables.