### PR TITLE
fix prometheus metric names

### DIFF
--- a/utils/services/prometheus.js
+++ b/utils/services/prometheus.js
@@ -13,30 +13,30 @@ class PrometheusWorker extends BaseServiceWorker {
           res.statusCode = 405;
           return res.end("GET only");
         }
-        res.write(`# HELP command_count Number of times a command has been run
-# TYPE command_count counter
+        res.write(`# HELP esmbot_command_count Number of times a command has been run
+# TYPE esmbot_command_count counter
 `);
         if (process.env.API === "true") {
           const servers = await this.ipc.command("image", { type: "stats" }, true);
-          res.write(`# HELP connected_workers Number of workers connected
-# TYPE connected_workers gauge
-connected_workers ${servers.length}
-# HELP running_jobs Number of running jobs on this worker
-# TYPE running_jobs gauge
-# HELP queued_jobs Number of queued jobs on this worker
-# TYPE queued_jobs gauge
-# HELP max_jobs Number of max allowed jobs on this worker
-# TYPE max_jobs gauge
+          res.write(`# HELP esmbot_connected_workers Number of workers connected
+# TYPE esmbot_connected_workers gauge
+esmbot_connected_workers ${servers.length}
+# HELP esmbot_running_jobs Number of running jobs on this worker
+# TYPE esmbot_running_jobs gauge
+# HELP esmbot_queued_jobs Number of queued jobs on this worker
+# TYPE esmbot_queued_jobs gauge
+# HELP esmbot_max_jobs Number of max allowed jobs on this worker
+# TYPE esmbot_max_jobs gauge
 `);
           for (const [i, w] of servers.entries()) {
-            res.write(`running_jobs{worker="${i}"} ${w.runningJobs}\n`);
-            res.write(`queued_jobs{worker="${i}"} ${w.queued}\n`);
-            res.write(`max_jobs{worker="${i}"} ${w.max}\n`);
+            res.write(`esmbot_running_jobs{worker="${i}"} ${w.runningJobs}\n`);
+            res.write(`esmbot_queued_jobs{worker="${i}"} ${w.queued}\n`);
+            res.write(`esmbot_max_jobs{worker="${i}"} ${w.max}\n`);
           }
         }
         const counts = await database.getCounts();
         for (const [i, w] of Object.entries(counts)) {
-          res.write(`command_count{command="${i}"} ${w}\n`);
+          res.write(`esmbot_command_count{command="${i}"} ${w}\n`);
         }
         res.end();
       });


### PR DESCRIPTION
> A metric name should have a (single-word) application prefix relevant to the domain the metric belongs to.

https://prometheus.io/docs/practices/naming/