### PR TITLE
Make the em dash (—) also work when using options

### DIFF
--- a/utils/parseCommand.js
+++ b/utils/parseCommand.js
@@ -5,9 +5,9 @@ export default (input) => {
   let concated = "";
   for (let i = 0; i < input.length; i++) {
     const a = input[i];
-    if (a.startsWith("--") && !curr) {
+    if ((a.startsWith("--") || a.startsWith("—")) && !curr) {
       if (a.includes("=")) {
-        const [arg, value] = a.slice(2).split("=");
+        const [arg, value] = (a.startsWith("--") ? a.slice(2).split("=") : a.slice(1).split("="));
         let ended = true;
         if (arg !== "_") {
           if (value.startsWith("\"")) {


### PR DESCRIPTION
Some devices (such as iPhones) automatically change it to `—` when you type `--`. To get it to stay as `--` you have to type something like `-f-` and then delete the `f`, which can be annoying. Some people probably don't realize this problem and wonder why it didn't work. Allowing both should make for a better user experience.