### PR TITLE
Make the play command play the first attachment if there is one and no arguments are given

### DIFF
--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -5,9 +5,10 @@ const searchRegex = /^ytsearch:/;
 
 class PlayCommand extends MusicCommand {
   async run() {
-    if (!this.args[0]) return "You need to provide what you want to play!";
+    if (!this.args[0] && this.message.attachments.length <= 0) return "You need to provide what you want to play!";
     const query = this.args.join(" ").trim();
-    const search = urlRegex.test(query) ? query : (searchRegex.test(query) ? query : `ytsearch:${query}`);
+    const attachment = this.message.attachments[0];
+    const search = urlRegex.test(query) ? query : searchRegex.test(query) ? query : !this.args[0] && attachment ? attachment.url : `ytsearch:${query}`;
     return await play(this.client, search, this.message, true);
   }
 


### PR DESCRIPTION
I've seen a few people want to play videos or audio uploaded straight to Discord with the play command on my own self-hosted instance. Since the command does support any file URL if it has audio, I cut the middleman of needing to copy the URL from an uploaded video/audio and then inputting it to the bot.

This change makes the argument a priority rather than the attachment if both are present. It only attempts to play the first attachment so phone users uploading multiple files would need to pay attention to that (most don't anyway, right?). You can add a check to play the first supported file from the array if there's a sane (non-handmade Regex) way to do so. The bot has had no issues if attempting to play an unsupported file even before the change.

Tested on a self-hosted development instance secluded from my main instance.

(sorry for the mouthful of a PR/commit title, I wanted to be specific)