### PR TITLE
Allow THREAD_CREATE event

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,7 +80,6 @@ const Admiral = new Fleet({
       MESSAGE_REACTION_REMOVE_EMOJI: true,
       INVITE_CREATE: true,
       INVITE_DELETE: true,
-      THREAD_CREATE: true,
       THREAD_UPDATE: true,
       THREAD_DELETE: true,
       THREAD_LIST_SYNC: true


### PR DESCRIPTION
Currently, esmBot disables the THREAD_CREATE event. This has consequences, most notably that when a message is sent in a thread the bot has no information about it (such as guild). For example, since guild information is not known, the bot thinks the message was not sent in a guild, and thus does not check for a prefix.

Fixes #202, and probably #199 as well. 

I did not explicitly link #199 as I didn't test for it, but I think it's safe to assume that the issue is caused by the bot being unable to retrieve voice information as guild information is undefined.