### PR TITLE
Fetch latest Twemoji version

### DIFF
--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -2,10 +2,18 @@
 FROM node:alpine
 
 RUN apk --no-cache upgrade
-RUN apk add --no-cache git cmake msttcorefonts-installer python3 alpine-sdk ffmpeg \
+RUN apk add --no-cache git cmake msttcorefonts-installer python3 alpine-sdk ffmpeg wget rpm2cpio \
     zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev \
     libtool libwebp-dev libxml2-dev pango-dev freetype fontconfig \
 	vips vips-dev
+
+# gets latest version of twemoji
+RUN mkdir /tmp/twemoji \
+&& cd /tmp/twemoji \
+&& package=$(wget  --quiet -O - https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/ |  grep twitter-twemoji | grep -o 'href="[^"]*' | tail -c +7) \
+&& wget https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/$package && rpm2cpio $package | cpio -ivd \
+&& cp ./usr/share/fonts/twemoji/Twemoji.ttf /usr/share/fonts/Twemoji.ttf \
+&& rm -r /tmp/twemoji
 
 # liblqr needs to be built manually for magick to work
 # and because alpine doesn't have it in their repos


### PR DESCRIPTION
Does what https://github.com/esmBot/esmBot/pull/214 wanted to, but differently + gets latest version every time. Breakdown of each line:

`mkdir /tmp/twemoji`= Figured it was good practice to work in temp directories
`cd /tmp/twemoji`
`package=$(wget  --quiet -O - https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/ |  grep twitter-twemoji | grep -o 'href="[^"]*' | tail -c +7` = Defines $package to the latest name of the Twemoji package we want (e.g _twitter-twemoji-fonts-13.1.0-3.fc36.noarch.rpm_)
`wget https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/$package && rpm2cpio $package | cpio -ivd` = Using the $package variable, we download and extract the package.
`cp ./usr/share/fonts/twemoji/Twemoji.ttf /usr/share/fonts/Twemoji.ttf` = Copy the Twemoji font from the extracted contents to the font folder.
`rm -r /tmp/twemoji` = Tries to remove the temp directory (not forced)
