### PR TITLE
Fix Dockerfile crash

### DIFF
--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -5,15 +5,16 @@ RUN apk --no-cache upgrade
 RUN apk add --no-cache git cmake msttcorefonts-installer python3 alpine-sdk ffmpeg wget rpm2cpio \
     zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev \
     libtool libwebp-dev libxml2-dev pango-dev freetype fontconfig \
-	vips vips-dev
+	vips vips-dev grep
 
 # gets latest version of twemoji
-RUN mkdir /tmp/twemoji \
-&& cd /tmp/twemoji \
-&& package=$(wget  --quiet -O - https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/ |  grep twitter-twemoji | grep -o 'href="[^"]*' | tail -c +7) \
-&& wget https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/$package && rpm2cpio $package | cpio -ivd \
-&& cp ./usr/share/fonts/twemoji/Twemoji.ttf /usr/share/fonts/Twemoji.ttf \
-&& rm -r /tmp/twemoji
+RUN mkdir /tmp/twemoji
+RUN cd /tmp/twemoji
+RUN package=$(wget --quiet -O - https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/ | grep -Po '(?<=href=")twitter-twemoji-fonts-[^"]*' | tail -1) \
+	&& wget https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/$package \
+	&& rpm2cpio $package | cpio -ivd \
+	&& cp ./usr/share/fonts/twemoji/Twemoji.ttf /usr/share/fonts/Twemoji.ttf \
+	&& rm -r /tmp/twemoji
 
 # liblqr needs to be built manually for magick to work
 # and because alpine doesn't have it in their repos

--- a/Dockerfile.bot
+++ b/Dockerfile.bot
@@ -8,13 +8,13 @@ RUN apk add --no-cache git cmake msttcorefonts-installer python3 alpine-sdk ffmp
 	vips vips-dev grep
 
 # gets latest version of twemoji
-RUN mkdir /tmp/twemoji
-RUN cd /tmp/twemoji
-RUN package=$(wget --quiet -O - https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/ | grep -Po '(?<=href=")twitter-twemoji-fonts-[^"]*' | tail -1) \
-	&& wget https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/$package \
-	&& rpm2cpio $package | cpio -ivd \
-	&& cp ./usr/share/fonts/twemoji/Twemoji.ttf /usr/share/fonts/Twemoji.ttf \
-	&& rm -r /tmp/twemoji
+RUN mkdir /tmp/twemoji \
+&& cd /tmp/twemoji \
+&& package=$(wget --quiet -O - https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/ | grep -Po '(?<=href=")twitter-twemoji-fonts-[^"]*' | tail -1) \
+&& wget https://fedora.mirror.liteserver.nl/linux/development/rawhide/Everything/aarch64/os/Packages/t/$package \
+&& rpm2cpio $package | cpio -ivd \
+&& cp ./usr/share/fonts/twemoji/Twemoji.ttf /usr/share/fonts/Twemoji.ttf \
+&& rm -r /tmp/twemoji
 
 # liblqr needs to be built manually for magick to work
 # and because alpine doesn't have it in their repos


### PR DESCRIPTION
Encountered an issue while trying to use the `docker-compose.yml` file earlier, where the grep pattern originally used would incorrectly treat the `href="` portion of the text it finds as a URL, crashing the process.

This just gets the two versions of Twemoji from the mirror, with proper formatting, and chooses only the latest one with `tail -1`.