### PR TITLE
Updated lavasrc-plugin to 3.1.7

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -28,7 +28,7 @@ lavalink:
   plugins:
     - dependency: "com.github.esmBot:lava-xm-plugin:v0.2.1"
       repository: "https://jitpack.io"
-    - dependency: "com.github.TopiSenpai.LavaSrc:lavasrc-plugin:3.0.3"
+    - dependency: "com.github.TopiSenpai.LavaSrc:lavasrc-plugin:3.1.7"
       repository: "https://jitpack.io"
 
 plugins:


### PR DESCRIPTION
This prevents LavaLink from instantly crashing during startup due to it not being able to retrieve version 3.0.3 successfully anymore.