### PR TITLE
Changed upload info to match 25mb

### DIFF
--- a/utils/tempimages.js
+++ b/utils/tempimages.js
@@ -16,7 +16,7 @@ export async function upload(client, result, context, interaction = false) {
         url: imageURL
       },
       footer: {
-        text: "The result image was more than 8MB in size, so it was uploaded to an external site instead."
+        text: "The result image was more than 25MB in size, so it was uploaded to an external site instead."
       },
     }]
   };


### PR DESCRIPTION
Discord file limit is now 25mb. When a images surprasses 25mb, it still displays 8mb.