### PR TITLE
Fix static globe command output

### DIFF
--- a/natives/globe.cc
+++ b/natives/globe.cc
@@ -69,6 +69,8 @@ ArgumentMap Globe(string type, string *outType, char *BufferData, size_t BufferL
   void *buf;
   final.write_to_buffer(".gif", &buf, DataSize);
 
+  *outType = "gif";
+
   ArgumentMap output;
   output["buf"] = (char *)buf;
 


### PR DESCRIPTION
Apparently sending a GIF with the wrong extension makes Discord convert it into a static PNG, which is exactly what happens when the globe command is used on anything other than a GIF.