### PR TITLE
Removed unnecessary processor macros

### DIFF
--- a/natives/common.h
+++ b/natives/common.h
@@ -95,13 +95,6 @@ inline void loadFonts(string basePath) {
   }
 }
 
-#define MAP_HAS(ARRAY, KEY) (ARRAY.count(KEY) > 0)
-#define MAP_GET(ARRAY, KEY, TYPE)                 \
-  (MAP_HAS(ARRAY, KEY) ? get<TYPE>(ARRAY.at(KEY)) \
-                       : NULL)  // C++ has forced my hand
-#define MAP_GET_FALLBACK(ARRAY, KEY, TYPE, FALLBACK) \
-  (MAP_HAS(ARRAY, KEY) ? get<TYPE>(ARRAY.at(KEY)) : FALLBACK)
-
 #define ARG_TYPES std::variant<string, bool, int, float>
 
 const std::vector<double> zeroVec = {0, 0, 0, 0};

--- a/natives/watermark.cc
+++ b/natives/watermark.cc
@@ -21,7 +21,7 @@ ArgumentMap Watermark(string type, string *outType, char *BufferData,
   bool flipX = GetArgumentWithFallback<bool>(Arguments, "flipX", false);
   bool flipY = GetArgumentWithFallback<bool>(Arguments, "flipY", false);
 
-  bool mc = MAP_HAS(Arguments, "mc");
+  bool mc = MapContainsKey(Arguments, "mc");
 
   string basePath = GetArgument<string>(Arguments, "basePath");
 


### PR DESCRIPTION
``MAP_HAS`` has been replaced by it's better alternative: ``MapContainsKey`` 
``MAP_GET`` has not uses (assuming it was replaced by: ``GetArgument`` 
``MAP_GET_FALLBACK`` has no uses (assuming it was replaced by ``GetArgumentWithFallback``

Adjusted ``Watermark.cc`` to use newer ``MapContainsKey`` instead of ``MAP_HAS`` because ``MapContainsKey`` has a compile time definition and can be checked easily