### PR TITLE
Significant-ish C++/Native Code refactor :3c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ yarn.lock
 # Container outputs
 bot-temp/
 bot-help/
+
+#Kate stuff
+*.kate*

--- a/natives/blur.cc
+++ b/natives/blur.cc
@@ -7,13 +7,13 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Blur(string type, string *outType, char *BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t *DataSize) {
-  bool sharp = GetArgument<bool>(Arguments, "sharp");
+ArgumentMap Blur(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  bool sharp = GetArgument<bool>(arguments, "sharp");
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
 
@@ -24,11 +24,10 @@ ArgumentMap Blur(string type, string *outType, char *BufferData, size_t BufferLe
   VImage out =
       sharp ? in.sharpen(VImage::option()->set("sigma", 3)) : in.gaussblur(15);
 
-  void *buf;
-  out.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
 
+  char* buf;
+  out.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
   ArgumentMap output;
-  output["buf"] = (char *)buf;
-
+  output["buf"] = buf;
   return output;
 }

--- a/natives/blur.h
+++ b/natives/blur.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Blur(string type, string* outType, char* BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t* DataSize);

--- a/natives/bounce.cc
+++ b/natives/bounce.cc
@@ -7,12 +7,11 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Bounce(string type, string *outType, char *BufferData,
-             size_t BufferLength, [[maybe_unused]] ArgumentMap Arguments,
-             size_t *DataSize) {
+ArgumentMap Bounce(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
   VImage in =
       VImage::new_from_buffer(
-          BufferData, BufferLength, "",
+          bufferdata, bufferLength, "",
           type == "gif" ? VImage::option()->set("n", -1)->set("access", "sequential")
                         : 0)
           .colourspace(VIPS_INTERPRETATION_sRGB);
@@ -41,9 +40,9 @@ ArgumentMap Bounce(string type, string *outType, char *BufferData,
   }
 
   void *buf;
-  final.write_to_buffer(".gif", &buf, DataSize);
+  final.write_to_buffer(".gif", &buf, &dataSize);
 
-  *outType = "gif";
+  outType = "gif";
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/bounce.cc
+++ b/natives/bounce.cc
@@ -7,7 +7,7 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Bounce(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+ArgumentMap Bounce(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
 {
   VImage in =
       VImage::new_from_buffer(

--- a/natives/bounce.cc
+++ b/natives/bounce.cc
@@ -39,13 +39,13 @@ ArgumentMap Bounce(const string& type, string& outType, const char* bufferdata, 
     final.set("delay", delay);
   }
 
-  void *buf;
-  final.write_to_buffer(".gif", &buf, &dataSize);
+  char *buf;
+  final.write_to_buffer(".gif", reinterpret_cast<void**>(&buf), &dataSize);
 
   outType = "gif";
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/bounce.h
+++ b/natives/bounce.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Bounce(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/caption.cc
+++ b/natives/caption.cc
@@ -63,15 +63,15 @@ ArgumentMap Caption(const string& type, string& outType, const char* bufferdata,
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight + captionImage.height());
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/caption.cc
+++ b/natives/caption.cc
@@ -6,17 +6,16 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Caption(string type, string *outType, char *BufferData,
-                    size_t BufferLength, ArgumentMap Arguments,
-                    size_t *DataSize) {
-  string caption = GetArgument<string>(Arguments, "caption");
-  string font = GetArgument<string>(Arguments, "font");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Caption(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string caption = GetArgument<string>(arguments, "caption");
+  string font = GetArgument<string>(arguments, "font");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
 
@@ -66,8 +65,8 @@ ArgumentMap Caption(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/caption.cc
+++ b/natives/caption.cc
@@ -33,7 +33,7 @@ ArgumentMap Caption(const string& type, string& outType, const char* bufferdata,
 
   string captionText = "<span background=\"white\">" + caption + "</span>";
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   auto findResult = fontPaths.find(font);
   VImage text = VImage::text(
       captionText.c_str(),

--- a/natives/caption.h
+++ b/natives/caption.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Caption(string type, string* outType, char* BufferData, size_t BufferLength,
-              ArgumentMap Arguments, size_t* DataSize);

--- a/natives/caption2.cc
+++ b/natives/caption2.cc
@@ -67,15 +67,15 @@ ArgumentMap CaptionTwo(const string& type, string& outType, const char* bufferda
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight + captionImage.height());
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/caption2.cc
+++ b/natives/caption2.cc
@@ -7,18 +7,17 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap CaptionTwo(string type, string *outType, char *BufferData,
-                       size_t BufferLength, ArgumentMap Arguments,
-                       size_t *DataSize) {
-  bool top = GetArgument<bool>(Arguments, "top");
-  string caption = GetArgument<string>(Arguments, "caption");
-  string font = GetArgument<string>(Arguments, "font");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap CaptionTwo(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  bool top = GetArgument<bool>(arguments, "top");
+  string caption = GetArgument<string>(arguments, "caption");
+  string font = GetArgument<string>(arguments, "font");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
 
@@ -70,8 +69,8 @@ ArgumentMap CaptionTwo(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/caption2.cc
+++ b/natives/caption2.cc
@@ -34,7 +34,7 @@ ArgumentMap CaptionTwo(const string& type, string& outType, const char* bufferda
 
   string captionText = "<span background=\"white\">" + caption + "</span>";
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   auto findResult = fontPaths.find(font);
   VImage text = VImage::text(
       captionText.c_str(),

--- a/natives/caption2.h
+++ b/natives/caption2.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap CaptionTwo(string type, string* outType, char* BufferData, size_t BufferLength,
-                 ArgumentMap Arguments, size_t* DataSize);

--- a/natives/circle.cc
+++ b/natives/circle.cc
@@ -48,7 +48,7 @@ ArgumentMap Circle([[maybe_unused]] const string& type, string& outType, const c
   dataSize = blob.length();
 
   // workaround because the data is tied to the blob
-  char *data = (char *)malloc(dataSize);
+  char *data = reinterpret_cast<char*>(malloc(dataSize));
   memcpy(data, blob.data(), dataSize);
   
   ArgumentMap output;

--- a/natives/circle.cc
+++ b/natives/circle.cc
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace Magick;
 
-ArgumentMap Circle(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+ArgumentMap Circle([[maybe_unused]] const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]]  ArgumentMap arguments, size_t& dataSize)
 {
   Blob blob;
 

--- a/natives/circle.cc
+++ b/natives/circle.cc
@@ -12,16 +12,15 @@
 using namespace std;
 using namespace Magick;
 
-ArgumentMap Circle(string type, string *outType, char *BufferData,
-             size_t BufferLength, [[maybe_unused]] ArgumentMap Arguments,
-             size_t *DataSize) {
+ArgumentMap Circle(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
   Blob blob;
 
   list<Image> frames;
   list<Image> coalesced;
   list<Image> blurred;
   try {
-    readImages(&frames, Blob(BufferData, BufferLength));
+    readImages(&frames, Blob(bufferdata, bufferLength));
   } catch (Magick::WarningCoder &warning) {
     cerr << "Coder Warning: " << warning.what() << endl;
   } catch (Magick::Warning &warning) {
@@ -31,13 +30,13 @@ ArgumentMap Circle(string type, string *outType, char *BufferData,
 
   for (Image &image : coalesced) {
     image.rotationalBlur(10);
-    image.magick(*outType);
+    image.magick(outType);
     blurred.push_back(image);
   }
 
   optimizeTransparency(blurred.begin(), blurred.end());
 
-  if (*outType == "gif") {
+  if (outType == "gif") {
     for (Image &image : blurred) {
       image.quantizeDitherMethod(FloydSteinbergDitherMethod);
       image.quantize();
@@ -46,11 +45,11 @@ ArgumentMap Circle(string type, string *outType, char *BufferData,
 
   writeImages(blurred.begin(), blurred.end(), &blob);
 
-  *DataSize = blob.length();
+  dataSize = blob.length();
 
   // workaround because the data is tied to the blob
-  char *data = (char *)malloc(*DataSize);
-  memcpy(data, blob.data(), *DataSize);
+  char *data = (char *)malloc(dataSize);
+  memcpy(data, blob.data(), dataSize);
   
   ArgumentMap output;
   output["buf"] = data;

--- a/natives/circle.h
+++ b/natives/circle.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Circle(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/colors.cc
+++ b/natives/colors.cc
@@ -10,14 +10,14 @@ using namespace vips;
 VImage sepia = VImage::new_matrixv(3, 3, 0.3588, 0.7044, 0.1368, 0.2990, 0.5870,
                                    0.1140, 0.2392, 0.4696, 0.0912);
 
-ArgumentMap Colors(string type, string *outType, char *BufferData,
-             size_t BufferLength, ArgumentMap Arguments, size_t *DataSize) {
-  string color = GetArgument<string>(Arguments, "color");
+ArgumentMap Colors(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string color = GetArgument<string>(arguments, "color");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
 
@@ -30,7 +30,7 @@ ArgumentMap Colors(string type, string *outType, char *BufferData,
   }
 
   void *buf;
-  out.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
+  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/colors.cc
+++ b/natives/colors.cc
@@ -29,11 +29,11 @@ ArgumentMap Colors(const string& type, string& outType, const char* bufferdata, 
     out = in.extract_band(0, VImage::option()->set("n", 3)).recomb(sepia);
   }
 
-  void *buf;
-  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
+  char *buf;
+  out.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/colors.h
+++ b/natives/colors.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Colors(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/commands.h
+++ b/natives/commands.h
@@ -12,9 +12,9 @@ declare_input_func(Blur);
 declare_input_func(Bounce);
 declare_input_func(Caption);
 declare_input_func(CaptionTwo);
-
+#if MAGICK_ENABLED
 declare_input_func(Circle);
-
+#endif
 declare_input_func(Colors);
 declare_input_func(Crop);
 declare_input_func(Deepfry);
@@ -26,9 +26,9 @@ declare_input_func(Gamexplain);
 declare_input_func(Globe);
 declare_input_func(Invert);
 declare_input_func(Jpeg);
-
+#if MAGICK_ENABLED
 declare_input_func(Magik);
-
+#endif
 declare_input_func(Meme);
 declare_input_func(Mirror);
 declare_input_func(Motivate);
@@ -38,9 +38,9 @@ declare_input_func(Reverse);
 declare_input_func(Scott);
 declare_input_func(Snapchat);
 declare_input_func(Speed);
-
+#if MAGICK_ENABLED
 declare_input_func(Spin);
-
+#endif
 declare_input_func(Spotify);
 declare_input_func(Squish);
 declare_input_func(Swirl);
@@ -48,9 +48,9 @@ declare_input_func(Tile);
 declare_input_func(ToGif);
 declare_input_func(Uncanny);
 declare_input_func(Uncaption);
-
+#if MAGICK_ENABLED
 declare_input_func(Wall);
-
+#endif
 declare_input_func(Watermark);
 declare_input_func(Whisper);
 

--- a/natives/commands.h
+++ b/natives/commands.h
@@ -2,8 +2,6 @@
 
 // Vultu: These are both bad, but I wanted to clean up code at least a little
 using std::string;
-
-
 #define declare_input_func(NAME) ArgumentMap NAME(const string& type, string& outType, const char* bufferData, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
 #define declare_noinput_func(NAME) ArgumentMap NAME(const string& type, string& outType, ArgumentMap arguments, size_t& dataSize)
 

--- a/natives/commands.h
+++ b/natives/commands.h
@@ -1,0 +1,60 @@
+#pragma once
+
+// Vultu: These are both bad, but I wanted to clean up code at least a little
+using std::string;
+
+
+#define declare_input_func(NAME) ArgumentMap NAME(const string& type, string& outType, const char* bufferData, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+#define declare_noinput_func(NAME) ArgumentMap NAME(const string& type, string& outType, ArgumentMap arguments, size_t& dataSize)
+
+// Declare our Input Functions
+declare_input_func(Blur);
+declare_input_func(Bounce);
+declare_input_func(Caption);
+declare_input_func(CaptionTwo);
+
+declare_input_func(Circle);
+
+declare_input_func(Colors);
+declare_input_func(Crop);
+declare_input_func(Deepfry);
+declare_input_func(Distort);
+declare_input_func(Flag);
+declare_input_func(Flip);
+declare_input_func(Freeze);
+declare_input_func(Gamexplain);
+declare_input_func(Globe);
+declare_input_func(Invert);
+declare_input_func(Jpeg);
+
+declare_input_func(Magik);
+
+declare_input_func(Meme);
+declare_input_func(Mirror);
+declare_input_func(Motivate);
+declare_input_func(Reddit);
+declare_input_func(Resize);
+declare_input_func(Reverse);
+declare_input_func(Scott);
+declare_input_func(Snapchat);
+declare_input_func(Speed);
+
+declare_input_func(Spin);
+
+declare_input_func(Spotify);
+declare_input_func(Squish);
+declare_input_func(Swirl);
+declare_input_func(Tile);
+declare_input_func(ToGif);
+declare_input_func(Uncanny);
+declare_input_func(Uncaption);
+
+declare_input_func(Wall);
+
+declare_input_func(Watermark);
+declare_input_func(Whisper);
+
+// Declare our No-Input Functions
+
+declare_noinput_func(Homebrew);
+declare_noinput_func(Sonic);

--- a/natives/common.cc
+++ b/natives/common.cc
@@ -1,0 +1,27 @@
+#include "common.h"
+
+void LoadFonts(string basePath)
+{
+  // manually loading fonts to workaround some font issues with libvips
+  if (!FcConfigAppFontAddDir(
+          NULL, (const FcChar8*)(basePath + "assets/fonts/").c_str())) {
+    std::cerr
+        << "Unable to load local font files from directory, falling back to "
+           "global fonts (which may be inaccurate!)"
+        << std::endl;
+  }
+  if (!FcConfigParseAndLoad(
+          FcConfigGetCurrent(),
+          (const FcChar8*)(basePath + "assets/fonts/fontconfig.xml").c_str(),
+          true)) {
+    std::cerr
+        << "Unable to load local fontconfig, some fonts may be inaccurate!"
+        << std::endl;
+  }
+}
+
+bool MapContainsKey(const ArgumentMap& map, const string& key)
+{
+  ArgumentMap::const_iterator it = map.find(key);
+  return it != map.end();
+}

--- a/natives/common.h
+++ b/natives/common.h
@@ -66,9 +66,9 @@ const std::unordered_map<std::string, std::string> fontPaths{
     {"roboto", "assets/fonts/reddit.ttf"}};
 
 const std::map<std::string,
-               ArgumentMap (*)(const string& type, string& outType, const char* BufferData,
-                               size_t BufferLength, ArgumentMap Arguments,
-                               size_t& DataSize)>
+               ArgumentMap (*)(const string& type, string& outType, const char* bufferData,
+                               size_t bufferLength, ArgumentMap arguments,
+                               size_t& dataSize)>
     FunctionMap = {{"blur", &Blur},
                    {"bounce", &Bounce},
                    {"caption", &Caption},
@@ -117,5 +117,5 @@ const std::map<std::string,
 
 const std::map<std::string,
                ArgumentMap (*)(const string& type, string& outType,
-                               ArgumentMap Arguments, size_t& DataSize)>
+                               ArgumentMap arguments, size_t& dataSize)>
     NoInputFunctionMap = {{"homebrew", &Homebrew}, {"sonic", &Sonic}};

--- a/natives/common.h
+++ b/natives/common.h
@@ -95,8 +95,6 @@ inline void loadFonts(string basePath) {
   }
 }
 
-#define ARG_TYPES std::variant<string, bool, int, float>
-
 const std::vector<double> zeroVec = {0, 0, 0, 0};
 const std::vector<double> zeroVecOneAlpha = {0, 0, 0, 1};
 

--- a/natives/common.h
+++ b/natives/common.h
@@ -95,13 +95,6 @@ inline void loadFonts(string basePath) {
   }
 }
 
-#define MAP_HAS(ARRAY, KEY) (ARRAY.count(KEY) > 0)
-#define MAP_GET(ARRAY, KEY, TYPE)                 \
-  (MAP_HAS(ARRAY, KEY) ? get<TYPE>(ARRAY.at(KEY)) \
-                       : NULL)  // C++ has forced my hand
-#define MAP_GET_FALLBACK(ARRAY, KEY, TYPE, FALLBACK) \
-  (MAP_HAS(ARRAY, KEY) ? get<TYPE>(ARRAY.at(KEY)) : FALLBACK)
-
 #define ARG_TYPES std::variant<string, bool, int, float>
 
 const std::vector<double> zeroVec = {0, 0, 0, 0};

--- a/natives/common.h
+++ b/natives/common.h
@@ -16,45 +16,7 @@ using std::variant;
 typedef variant<char*, string, float, bool, int> ArgumentVariant;
 typedef map<string, ArgumentVariant> ArgumentMap;
 
-#include "blur.h"
-#include "bounce.h"
-#include "caption.h"
-#include "caption2.h"
-#include "circle.h"
-#include "colors.h"
-#include "crop.h"
-#include "deepfry.h"
-#include "distort.h"
-#include "flag.h"
-#include "flip.h"
-#include "freeze.h"
-#include "gamexplain.h"
-#include "globe.h"
-#include "homebrew.h"
-#include "invert.h"
-#include "jpeg.h"
-#include "magik.h"
-#include "meme.h"
-#include "mirror.h"
-#include "motivate.h"
-#include "reddit.h"
-#include "resize.h"
-#include "reverse.h"
-#include "scott.h"
-#include "snapchat.h"
-#include "sonic.h"
-#include "speed.h"
-#include "spin.h"
-#include "spotify.h"
-#include "squish.h"
-#include "swirl.h"
-#include "tile.h"
-#include "togif.h"
-#include "uncanny.h"
-#include "uncaption.h"
-#include "wall.h"
-#include "watermark.h"
-#include "whisper.h"
+#include "commands.h"
 
 inline bool MapContainsKey(const ArgumentMap& map, const string& key)
 {
@@ -104,9 +66,9 @@ const std::unordered_map<std::string, std::string> fontPaths{
     {"roboto", "assets/fonts/reddit.ttf"}};
 
 const std::map<std::string,
-               ArgumentMap (*)(string type, string* outType, char* BufferData,
+               ArgumentMap (*)(const string& type, string& outType, const char* BufferData,
                                size_t BufferLength, ArgumentMap Arguments,
-                               size_t* DataSize)>
+                               size_t& DataSize)>
     FunctionMap = {{"blur", &Blur},
                    {"bounce", &Bounce},
                    {"caption", &Caption},
@@ -154,6 +116,6 @@ const std::map<std::string,
                    {"whisper", &Whisper}};
 
 const std::map<std::string,
-               ArgumentMap (*)(string type, string* outType,
-                               ArgumentMap Arguments, size_t* DataSize)>
+               ArgumentMap (*)(const string& type, string& outType,
+                               ArgumentMap Arguments, size_t& DataSize)>
     NoInputFunctionMap = {{"homebrew", &Homebrew}, {"sonic", &Sonic}};

--- a/natives/common.h
+++ b/natives/common.h
@@ -18,11 +18,8 @@ typedef map<string, ArgumentVariant> ArgumentMap;
 
 #include "commands.h"
 
-inline bool MapContainsKey(const ArgumentMap& map, const string& key)
-{
-  ArgumentMap::const_iterator it = map.find(key);
-  return it != map.end();
-}
+void LoadFonts(string basePath);
+bool MapContainsKey(const ArgumentMap& map, const string& key);
 
 template <typename T>
 T GetArgument(ArgumentMap map, string key) {
@@ -38,24 +35,6 @@ T GetArgumentWithFallback(ArgumentMap map, string key, T fallback) {
   return std::get<T>(map.at(key));
 }
 
-inline void loadFonts(string basePath) {
-  // manually loading fonts to workaround some font issues with libvips
-  if (!FcConfigAppFontAddDir(
-          NULL, (const FcChar8*)(basePath + "assets/fonts/").c_str())) {
-    std::cerr
-        << "Unable to load local font files from directory, falling back to "
-           "global fonts (which may be inaccurate!)"
-        << std::endl;
-  }
-  if (!FcConfigParseAndLoad(
-          FcConfigGetCurrent(),
-          (const FcChar8*)(basePath + "assets/fonts/fontconfig.xml").c_str(),
-          true)) {
-    std::cerr
-        << "Unable to load local fontconfig, some fonts may be inaccurate!"
-        << std::endl;
-  }
-}
 
 const std::vector<double> zeroVec = {0, 0, 0, 0};
 const std::vector<double> zeroVecOneAlpha = {0, 0, 0, 1};

--- a/natives/crop.cc
+++ b/natives/crop.cc
@@ -7,12 +7,12 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Crop(string type, string *outType, char *BufferData, size_t BufferLength,
-           [[maybe_unused]] ArgumentMap Arguments, size_t *DataSize) {
+ArgumentMap Crop(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
 
@@ -42,8 +42,8 @@ ArgumentMap Crop(string type, string *outType, char *BufferData, size_t BufferLe
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/crop.cc
+++ b/natives/crop.cc
@@ -40,15 +40,15 @@ ArgumentMap Crop(const string& type, string& outType, const char* bufferdata, si
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, finalHeight);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/crop.h
+++ b/natives/crop.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Crop(string type, string* outType, char* BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t* DataSize);

--- a/natives/deepfry.cc
+++ b/natives/deepfry.cc
@@ -6,13 +6,12 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Deepfry(string type, string *outType, char *BufferData,
-              size_t BufferLength, [[maybe_unused]] ArgumentMap Arguments,
-              size_t *DataSize) {
+ArgumentMap Deepfry(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
 
@@ -54,8 +53,8 @@ ArgumentMap Deepfry(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif" ? VImage::option()->set("dither", 0) : 0);
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif" ? VImage::option()->set("dither", 0) : 0);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/deepfry.cc
+++ b/natives/deepfry.cc
@@ -51,13 +51,13 @@ ArgumentMap Deepfry(const string& type, string& outType, const char* bufferdata,
     if (type == "gif") final.set("delay", fried.get_array_int("delay"));
   }
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif" ? VImage::option()->set("dither", 0) : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/deepfry.h
+++ b/natives/deepfry.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Deepfry(string type, string* outType, char* BufferData, size_t BufferLength,
-              ArgumentMap Arguments, size_t* DataSize);

--- a/natives/distort.cc
+++ b/natives/distort.cc
@@ -5,15 +5,14 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Distort(string type, string *outType, char *BufferData,
-                    size_t BufferLength, ArgumentMap Arguments,
-                    size_t *DataSize) {
-  string mapName = GetArgument<string>(Arguments, "mapName");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Distort(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string mapName = GetArgument<string>(arguments, "mapName");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VImage in =
       VImage::new_from_buffer(
-          BufferData, BufferLength, "",
+          bufferdata, bufferLength, "",
           type == "gif" ? VImage::option()->set("n", -1)->set("access", "sequential")
                         : 0)
           .colourspace(VIPS_INTERPRETATION_sRGB);
@@ -44,7 +43,7 @@ ArgumentMap Distort(string type, string *outType, char *BufferData,
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight);
 
   void *buf;
-  final.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
+  final.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/distort.cc
+++ b/natives/distort.cc
@@ -42,11 +42,11 @@ ArgumentMap Distort(const string& type, string& outType, const char* bufferdata,
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight);
 
-  void *buf;
-  final.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
+  char *buf;
+  final.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/distort.h
+++ b/natives/distort.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Distort(string type, string* outType, char* BufferData, size_t BufferLength,
-              ArgumentMap Arguments, size_t* DataSize);

--- a/natives/flag.cc
+++ b/natives/flag.cc
@@ -38,15 +38,15 @@ ArgumentMap Flag(const string& type, string& outType, const char* bufferdata, si
   VImage replicated = overlayImage.replicate(1, nPages);
   VImage final = in.composite2(replicated, VIPS_BLEND_MODE_OVER);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/flag.cc
+++ b/natives/flag.cc
@@ -5,15 +5,15 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Flag(string type, string *outType, char *BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t *DataSize) {
-  string overlay = GetArgument<string>(Arguments, "overlay");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Flag(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string overlay = GetArgument<string>(arguments, "overlay");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
 
@@ -40,8 +40,8 @@ ArgumentMap Flag(string type, string *outType, char *BufferData, size_t BufferLe
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/flag.h
+++ b/natives/flag.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Flag(string type, string* outType, char* BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t* DataSize);

--- a/natives/flip.cc
+++ b/natives/flip.cc
@@ -37,15 +37,15 @@ ArgumentMap Flip(const string& type, string& outType, const char* bufferdata, si
     out = in.flip(VIPS_DIRECTION_VERTICAL);
   }
 
-  void *buf;
+  char *buf;
   out.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/flip.cc
+++ b/natives/flip.cc
@@ -6,11 +6,11 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Flip(string type, string *outType, char *BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t *DataSize) {
-  bool flop = GetArgumentWithFallback<bool>(Arguments, "flop", false);
+ArgumentMap Flip(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  bool flop = GetArgumentWithFallback<bool>(arguments, "flop", false);
 
-  VImage in = VImage::new_from_buffer(BufferData, BufferLength, "",
+  VImage in = VImage::new_from_buffer(bufferdata, bufferLength, "",
                                       type == "gif"
                                           ? VImage::option()->set("n", -1)->set(
                                                 "access", "sequential")
@@ -39,8 +39,8 @@ ArgumentMap Flip(string type, string *outType, char *BufferData, size_t BufferLe
 
   void *buf;
   out.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/flip.h
+++ b/natives/flip.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Flip(string type, string* outType, char* BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t* DataSize);

--- a/natives/freeze.cc
+++ b/natives/freeze.cc
@@ -12,23 +12,23 @@ ArgumentMap Freeze(const string& type, string& outType, const char* bufferdata, 
   bool loop = GetArgumentWithFallback<bool>(arguments, "loop", false);
   int frame = GetArgumentWithFallback<int>(arguments, "frame", -1);
 
-  char *fileData = (char *)malloc(bufferLength);
+  char *fileData = reinterpret_cast<char*>(malloc(bufferLength));
   memcpy(fileData, bufferdata, bufferLength);
 
-  char *match = (char *)"\x21\xFF\x0BNETSCAPE2.0\x03\x01";
-  char *descriptor = (char *)"\x2C\x00\x00\x00\x00";
+  char *match = const_cast<char*>("\x21\xFF\x0BNETSCAPE2.0\x03\x01");
+  char *descriptor = const_cast<char*>("\x2C\x00\x00\x00\x00");
   char *lastPos;
 
   bool none = true;
 
   if (loop) {
-    char *newData = (char *)malloc(bufferLength + 19);
+    char *newData = reinterpret_cast<char*>(malloc(bufferLength + 19));
     memcpy(newData, fileData, bufferLength);
-    lastPos = (char *)memchr(newData, '\x2C', bufferLength);
+    lastPos = reinterpret_cast<char*>(memchr(newData, '\x2C', bufferLength));
     while (lastPos != NULL) {
       if (memcmp(lastPos, descriptor, 5) != 0) {
-        lastPos = (char *)memchr(lastPos + 1, '\x2C',
-                                 (bufferLength - (lastPos - newData)) - 1);
+        lastPos = reinterpret_cast<char*>(memchr(lastPos + 1, '\x2C',
+                                 (bufferLength - (lastPos - newData)) - 1));
         continue;
       }
 
@@ -62,20 +62,20 @@ ArgumentMap Freeze(const string& type, string& outType, const char* bufferdata, 
     out.set(VIPS_META_PAGE_HEIGHT, pageHeight);
     out.set("loop", 1);
 
-    void *buf;
-    out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
+    char *buf;
+    out.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
 
     ArgumentMap output;
-    output["buf"] = (char *)buf;
+    output["buf"] = buf;
 
     return output;
     
   } else {
-    lastPos = (char *)memchr(fileData, '\x21', bufferLength);
+    lastPos = reinterpret_cast<char*>(memchr(fileData, '\x21', bufferLength));
     while (lastPos != NULL) {
       if (memcmp(lastPos, match, 16) != 0) {
-        lastPos = (char *)memchr(lastPos + 1, '\x21',
-                                 (bufferLength - (lastPos - fileData)) - 1);
+        lastPos = reinterpret_cast<char*>(memchr(lastPos + 1, '\x21',
+                                 (bufferLength - (lastPos - fileData)) - 1));
         continue;
       }
       memcpy(lastPos, lastPos + 19, (bufferLength - (lastPos - fileData)) - 19);

--- a/natives/freeze.cc
+++ b/natives/freeze.cc
@@ -7,13 +7,13 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Freeze(string type, string *outType, char *BufferData,
-             size_t BufferLength, ArgumentMap Arguments, size_t *DataSize) {
-  bool loop = GetArgumentWithFallback<bool>(Arguments, "loop", false);
-  int frame = GetArgumentWithFallback<int>(Arguments, "frame", -1);
+ArgumentMap Freeze(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  bool loop = GetArgumentWithFallback<bool>(arguments, "loop", false);
+  int frame = GetArgumentWithFallback<int>(arguments, "frame", -1);
 
-  char *fileData = (char *)malloc(BufferLength);
-  memcpy(fileData, BufferData, BufferLength);
+  char *fileData = (char *)malloc(bufferLength);
+  memcpy(fileData, bufferdata, bufferLength);
 
   char *match = (char *)"\x21\xFF\x0BNETSCAPE2.0\x03\x01";
   char *descriptor = (char *)"\x2C\x00\x00\x00\x00";
@@ -22,25 +22,25 @@ ArgumentMap Freeze(string type, string *outType, char *BufferData,
   bool none = true;
 
   if (loop) {
-    char *newData = (char *)malloc(BufferLength + 19);
-    memcpy(newData, fileData, BufferLength);
-    lastPos = (char *)memchr(newData, '\x2C', BufferLength);
+    char *newData = (char *)malloc(bufferLength + 19);
+    memcpy(newData, fileData, bufferLength);
+    lastPos = (char *)memchr(newData, '\x2C', bufferLength);
     while (lastPos != NULL) {
       if (memcmp(lastPos, descriptor, 5) != 0) {
         lastPos = (char *)memchr(lastPos + 1, '\x2C',
-                                 (BufferLength - (lastPos - newData)) - 1);
+                                 (bufferLength - (lastPos - newData)) - 1);
         continue;
       }
 
-      memcpy(lastPos + 19, lastPos, (BufferLength - (lastPos - newData)));
+      memcpy(lastPos + 19, lastPos, (bufferLength - (lastPos - newData)));
       memcpy(lastPos, match, 16);
       memcpy(lastPos + 16, "\x00\x00\x00", 3);
 
       none = false;
-      *DataSize = BufferLength + 19;
+      dataSize = bufferLength + 19;
       break;
     }
-    if (none) *DataSize = BufferLength;
+    if (none) dataSize = bufferLength;
 
     ArgumentMap output;
     output["buf"] = newData;
@@ -50,7 +50,7 @@ ArgumentMap Freeze(string type, string *outType, char *BufferData,
     VOption *options = VImage::option()->set("access", "sequential");
 
     VImage in =
-        VImage::new_from_buffer(BufferData, BufferLength, "",
+        VImage::new_from_buffer(bufferdata, bufferLength, "",
                                 type == "gif" ? options->set("n", -1) : options)
             .colourspace(VIPS_INTERPRETATION_sRGB);
     if (!in.has_alpha()) in = in.bandjoin(255);
@@ -63,7 +63,7 @@ ArgumentMap Freeze(string type, string *outType, char *BufferData,
     out.set("loop", 1);
 
     void *buf;
-    out.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
+    out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
 
     ArgumentMap output;
     output["buf"] = (char *)buf;
@@ -71,19 +71,19 @@ ArgumentMap Freeze(string type, string *outType, char *BufferData,
     return output;
     
   } else {
-    lastPos = (char *)memchr(fileData, '\x21', BufferLength);
+    lastPos = (char *)memchr(fileData, '\x21', bufferLength);
     while (lastPos != NULL) {
       if (memcmp(lastPos, match, 16) != 0) {
         lastPos = (char *)memchr(lastPos + 1, '\x21',
-                                 (BufferLength - (lastPos - fileData)) - 1);
+                                 (bufferLength - (lastPos - fileData)) - 1);
         continue;
       }
-      memcpy(lastPos, lastPos + 19, (BufferLength - (lastPos - fileData)) - 19);
-      *DataSize = BufferLength - 19;
+      memcpy(lastPos, lastPos + 19, (bufferLength - (lastPos - fileData)) - 19);
+      dataSize = bufferLength - 19;
       none = false;
       break;
     }
-    if (none) *DataSize = BufferLength;
+    if (none) dataSize = bufferLength;
 
     ArgumentMap output;
     output["buf"] = fileData;

--- a/natives/freeze.h
+++ b/natives/freeze.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Freeze(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/gamexplain.cc
+++ b/natives/gamexplain.cc
@@ -39,15 +39,15 @@ ArgumentMap Gamexplain(const string& type, string& outType, const char* bufferda
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, 675);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/gamexplain.cc
+++ b/natives/gamexplain.cc
@@ -5,14 +5,14 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Gamexplain(string type, string *outType, char *BufferData,
-                 size_t BufferLength, ArgumentMap Arguments, size_t *DataSize) {
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Gamexplain(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -41,8 +41,8 @@ ArgumentMap Gamexplain(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/gamexplain.h
+++ b/natives/gamexplain.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Gamexplain(string type, string* outType, char* BufferData, size_t BufferLength,
-                 ArgumentMap Arguments, size_t* DataSize);

--- a/natives/generic/image.cc
+++ b/natives/generic/image.cc
@@ -24,7 +24,7 @@ struct image_result {
   void *buf;
 };
 
-image_result *image(char *command, char *args, char *data, size_t length) {
+image_result *image(const char *command, const char *args, const char *data, size_t length) {
   nlohmann::json parsedArgs = nlohmann::json::parse(args);
   ArgumentMap Arguments;
 
@@ -53,12 +53,19 @@ image_result *image(char *command, char *args, char *data, size_t length) {
 
   size_t outLength = 0;
   ArgumentMap outMap;
-  if (length == 0) {
-    outMap = FunctionMap.at(command)(type, &outType, data, length, Arguments,
-                                     &outLength);
-  } else {
-    outMap =
-        NoInputFunctionMap.at(command)(type, &outType, Arguments, &outLength);
+  if (length == 0)
+  {
+    if (MapContainsKey(FunctionMap, command))
+      outMap = FunctionMap.at(command)(type, outType, data, length, Arguments, &outLength);
+    else // Vultu: I don't think we will ever be here, but just in case we need a descriptive error
+      throw "Error: \"FunctionMap\" does not contain \""" + command + "\", which was requested because \"length\" parameter was 0."
+  }
+  else
+  {
+    if (MapContainsKey(NoInputFunctionMap, command))
+      outMap = NoInputFunctionMap.at(command)(type, outType, Arguments, &outLength);
+    else
+      throw "Error: \"NoInputFunctionMap\" does not contain \""" + command + "\", which was requested because \"length\" parameter was not 0."
   }
 
   vips_error_clear();

--- a/natives/globe.cc
+++ b/natives/globe.cc
@@ -5,13 +5,13 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Globe(string type, string *outType, char *BufferData, size_t BufferLength,
-            ArgumentMap Arguments, size_t *DataSize) {
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Globe(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VImage in =
       VImage::new_from_buffer(
-          BufferData, BufferLength, "",
+          bufferdata, bufferLength, "",
           type == "gif" ? VImage::option()->set("n", -1)->set("access", "sequential")
                          : 0)
           .colourspace(VIPS_INTERPRETATION_sRGB);
@@ -65,9 +65,9 @@ ArgumentMap Globe(string type, string *outType, char *BufferData, size_t BufferL
   }
 
   void *buf;
-  final.write_to_buffer(".gif", &buf, DataSize);
+  final.write_to_buffer(".gif", &buf, &dataSize);
 
-  *outType = "gif";
+  outType = "gif";
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/globe.cc
+++ b/natives/globe.cc
@@ -64,13 +64,13 @@ ArgumentMap Globe(const string& type, string& outType, const char* bufferdata, s
     final.set("delay", delay);
   }
 
-  void *buf;
-  final.write_to_buffer(".gif", &buf, &dataSize);
+  char *buf;
+  final.write_to_buffer(".gif", reinterpret_cast<void**>(&buf), &dataSize);
 
   outType = "gif";
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/globe.h
+++ b/natives/globe.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Globe(string type, string* outType, char* BufferData, size_t BufferLength,
-            ArgumentMap Arguments, size_t* DataSize);

--- a/natives/homebrew.cc
+++ b/natives/homebrew.cc
@@ -5,7 +5,7 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Homebrew(const string& type, string& outType, ArgumentMap arguments, size_t& dataSize)
+ArgumentMap Homebrew([[maybe_unused]] const string& type, string& outType, ArgumentMap arguments, size_t& dataSize)
 {
   string caption = GetArgument<string>(arguments, "caption");
   string basePath = GetArgument<string>(arguments, "basePath");
@@ -13,7 +13,7 @@ ArgumentMap Homebrew(const string& type, string& outType, ArgumentMap arguments,
   string assetPath = basePath + "assets/images/hbc.png";
   VImage bg = VImage::new_from_file(assetPath.c_str());
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   VImage text = VImage::text(
       ("<span letter_spacing=\"-5120\" color=\"white\">" + caption + "</span>")
           .c_str(),

--- a/natives/homebrew.cc
+++ b/natives/homebrew.cc
@@ -5,10 +5,10 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Homebrew(string type, string *outType, ArgumentMap Arguments,
-                     size_t *DataSize) {
-  string caption = GetArgument<string>(Arguments, "caption");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Homebrew(const string& type, string& outType, ArgumentMap arguments, size_t& dataSize)
+{
+  string caption = GetArgument<string>(arguments, "caption");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   string assetPath = basePath + "assets/images/hbc.png";
   VImage bg = VImage::new_from_file(assetPath.c_str());
@@ -29,7 +29,7 @@ ArgumentMap Homebrew(string type, string *outType, ArgumentMap Arguments,
                                  ->set("y", 300 - (text.height() / 2) - 8));
 
   void *buf;
-  out.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
+  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/homebrew.cc
+++ b/natives/homebrew.cc
@@ -28,11 +28,11 @@ ArgumentMap Homebrew([[maybe_unused]] const string& type, string& outType, Argum
                                  ->set("x", 400 - (text.width() / 2))
                                  ->set("y", 300 - (text.height() / 2) - 8));
 
-  void *buf;
-  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
+  char *buf;
+  out.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/homebrew.h
+++ b/natives/homebrew.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Homebrew(string type, string *outType, ArgumentMap Arguments, size_t *DataSize);

--- a/natives/invert.cc
+++ b/natives/invert.cc
@@ -20,11 +20,11 @@ ArgumentMap Invert(const string& type, string& outType, const char* bufferdata, 
   VImage inverted = noAlpha.invert();
   VImage out = inverted.bandjoin(in.extract_band(3));
 
-  void *buf;
-  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
+  char *buf;
+  out.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/invert.cc
+++ b/natives/invert.cc
@@ -5,13 +5,12 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Invert(string type, string *outType, char *BufferData,
-             size_t BufferLength, [[maybe_unused]] ArgumentMap Arguments,
-             size_t *DataSize) {
+ArgumentMap Invert(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -22,7 +21,7 @@ ArgumentMap Invert(string type, string *outType, char *BufferData,
   VImage out = inverted.bandjoin(in.extract_band(3));
 
   void *buf;
-  out.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
+  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/invert.h
+++ b/natives/invert.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Invert(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/jpeg.cc
+++ b/natives/jpeg.cc
@@ -5,15 +5,15 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Jpeg(string type, string *outType, char *BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t *DataSize) {
-  int quality = GetArgumentWithFallback<int>(Arguments, "quality", 0);
+ArgumentMap Jpeg(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  int quality = GetArgumentWithFallback<int>(arguments, "quality", 0);
 
   void *buf;
 
   if (type == "gif") {
     VImage in = VImage::new_from_buffer(
-                    BufferData, BufferLength, "",
+                    bufferdata, bufferLength, "",
                     VImage::option()->set("access", "sequential")->set("n", -1))
                     .colourspace(VIPS_INTERPRETATION_sRGB);
     if (!in.has_alpha()) in = in.bandjoin(255);
@@ -53,20 +53,20 @@ ArgumentMap Jpeg(string type, string *outType, char *BufferData, size_t BufferLe
     }
 
     final.write_to_buffer(
-        ("." + *outType).c_str(), &buf, DataSize,
-        *outType == "gif" ? VImage::option()->set("dither", 0) : 0);
+        ("." + outType).c_str(), &buf, &dataSize,
+        outType == "gif" ? VImage::option()->set("dither", 0) : 0);
   } else {
-    VImage in = VImage::new_from_buffer(BufferData, BufferLength, "");
+    VImage in = VImage::new_from_buffer(bufferdata, bufferLength, "");
     void *jpgBuf;
-    in.write_to_buffer(".jpg", &jpgBuf, DataSize,
+    in.write_to_buffer(".jpg", &jpgBuf, &dataSize,
                        VImage::option()->set("Q", quality)->set("strip", true));
-    if (*outType == "gif") {
-      VImage gifIn = VImage::new_from_buffer((char *)jpgBuf, *DataSize, "");
+    if (outType == "gif") {
+      VImage gifIn = VImage::new_from_buffer((char *)jpgBuf, dataSize, "");
       gifIn.write_to_buffer(
-          ".gif", &buf, DataSize,
+          ".gif", &buf, &dataSize,
           VImage::option()->set("Q", quality)->set("strip", true));
     } else {
-      *outType = "jpg";
+      outType = "jpg";
       buf = jpgBuf;
     }
   }

--- a/natives/jpeg.cc
+++ b/natives/jpeg.cc
@@ -9,7 +9,7 @@ ArgumentMap Jpeg(const string& type, string& outType, const char* bufferdata, si
 {
   int quality = GetArgumentWithFallback<int>(arguments, "quality", 0);
 
-  void *buf;
+  char *buf;
 
   if (type == "gif") {
     VImage in = VImage::new_from_buffer(
@@ -53,7 +53,7 @@ ArgumentMap Jpeg(const string& type, string& outType, const char* bufferdata, si
     }
 
     final.write_to_buffer(
-        ("." + outType).c_str(), &buf, &dataSize,
+        ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
         outType == "gif" ? VImage::option()->set("dither", 0) : 0);
   } else {
     VImage in = VImage::new_from_buffer(bufferdata, bufferLength, "");
@@ -61,18 +61,18 @@ ArgumentMap Jpeg(const string& type, string& outType, const char* bufferdata, si
     in.write_to_buffer(".jpg", &jpgBuf, &dataSize,
                        VImage::option()->set("Q", quality)->set("strip", true));
     if (outType == "gif") {
-      VImage gifIn = VImage::new_from_buffer((char *)jpgBuf, dataSize, "");
+      VImage gifIn = VImage::new_from_buffer(reinterpret_cast<char*>(jpgBuf), dataSize, "");
       gifIn.write_to_buffer(
-          ".gif", &buf, &dataSize,
+          ".gif", reinterpret_cast<void**>(&buf), &dataSize,
           VImage::option()->set("Q", quality)->set("strip", true));
     } else {
       outType = "jpg";
-      buf = jpgBuf;
+      buf = reinterpret_cast<char*>(jpgBuf);
     }
   }
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/jpeg.h
+++ b/natives/jpeg.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Jpeg(string type, string* outType, char* BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t* DataSize);

--- a/natives/magik.cc
+++ b/natives/magik.cc
@@ -47,7 +47,7 @@ ArgumentMap Magik([[maybe_unused]] const string& type, string& outType, const ch
 
   dataSize = blob.length();
 
-  char *data = (char *)malloc(dataSize);
+  char *data = reinterpret_cast<char*>(malloc(dataSize));
   memcpy(data, blob.data(), dataSize);
 
   ArgumentMap output;

--- a/natives/magik.cc
+++ b/natives/magik.cc
@@ -10,7 +10,7 @@
 using namespace std;
 using namespace Magick;
 
-ArgumentMap Magik(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+ArgumentMap Magik([[maybe_unused]] const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
 {
   Blob blob;
 

--- a/natives/magik.cc
+++ b/natives/magik.cc
@@ -10,15 +10,15 @@
 using namespace std;
 using namespace Magick;
 
-ArgumentMap Magik(string type, string *outType, char *BufferData, size_t BufferLength,
-            [[maybe_unused]] ArgumentMap Arguments, size_t *DataSize) {
+ArgumentMap Magik(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
   Blob blob;
 
   list<Image> frames;
   list<Image> coalesced;
   list<Image> blurred;
   try {
-    readImages(&frames, Blob(BufferData, BufferLength));
+    readImages(&frames, Blob(bufferdata, bufferLength));
   } catch (Magick::WarningCoder &warning) {
     cerr << "Coder Warning: " << warning.what() << endl;
   } catch (Magick::Warning &warning) {
@@ -30,13 +30,13 @@ ArgumentMap Magik(string type, string *outType, char *BufferData, size_t BufferL
     image.scale(Geometry("350x350"));
     image.liquidRescale(Geometry("175x175"));
     image.liquidRescale(Geometry("350x350"));
-    image.magick(*outType);
+    image.magick(outType);
     blurred.push_back(image);
   }
 
   optimizeTransparency(blurred.begin(), blurred.end());
 
-  if (*outType == "gif") {
+  if (outType == "gif") {
     for (Image &image : blurred) {
       image.quantizeDitherMethod(FloydSteinbergDitherMethod);
       image.quantize();
@@ -45,10 +45,10 @@ ArgumentMap Magik(string type, string *outType, char *BufferData, size_t BufferL
 
   writeImages(blurred.begin(), blurred.end(), &blob);
 
-  *DataSize = blob.length();
+  dataSize = blob.length();
 
-  char *data = (char *)malloc(*DataSize);
-  memcpy(data, blob.data(), *DataSize);
+  char *data = (char *)malloc(dataSize);
+  memcpy(data, blob.data(), dataSize);
 
   ArgumentMap output;
   output["buf"] = data;

--- a/natives/magik.h
+++ b/natives/magik.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Magik(string type, string* outType, char* BufferData, size_t BufferLength,
-            ArgumentMap Arguments, size_t* DataSize);

--- a/natives/meme.cc
+++ b/natives/meme.cc
@@ -24,17 +24,17 @@ VImage genText(string text, string font, const char *fontfile, int width,
   return outline.composite2(in, VIPS_BLEND_MODE_OVER);
 }
 
-ArgumentMap Meme(string type, string *outType, char *BufferData,
-                 size_t BufferLength, ArgumentMap Arguments, size_t *DataSize) {
-  string top = GetArgument<string>(Arguments, "top");
-  string bottom = GetArgument<string>(Arguments, "bottom");
-  string font = GetArgument<string>(Arguments, "font");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Meme(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string top = GetArgument<string>(arguments, "top");
+  string bottom = GetArgument<string>(arguments, "bottom");
+  string font = GetArgument<string>(arguments, "font");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -91,8 +91,8 @@ ArgumentMap Meme(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/meme.cc
+++ b/natives/meme.cc
@@ -57,7 +57,7 @@ ArgumentMap Meme(const string& type, string& outType, const char* bufferdata, si
   string fontResult =
       findResult != fontPaths.end() ? basePath + findResult->second : "";
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   VImage combinedText =
       VImage::black(width, pageHeight, VImage::option()->set("bands", 3))
           .bandjoin(0)

--- a/natives/meme.cc
+++ b/natives/meme.cc
@@ -89,15 +89,15 @@ ArgumentMap Meme(const string& type, string& outType, const char* bufferdata, si
                           .replicate(1, nPages);
   VImage final = in.composite(replicated, VIPS_BLEND_MODE_OVER);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/meme.h
+++ b/natives/meme.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Meme(string type, string* outType, char* BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t* DataSize);

--- a/natives/mirror.cc
+++ b/natives/mirror.cc
@@ -5,14 +5,13 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Mirror(string type, string *outType, char *BufferData,
-                   size_t BufferLength, ArgumentMap Arguments,
-                   size_t *DataSize) {
-  bool vertical = GetArgumentWithFallback<bool>(Arguments, "vertical", false);
-  bool first = GetArgumentWithFallback<bool>(Arguments, "first", false);
+ArgumentMap Mirror(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  bool vertical = GetArgumentWithFallback<bool>(arguments, "vertical", false);
+  bool first = GetArgumentWithFallback<bool>(arguments, "first", false);
 
   VImage in = VImage::new_from_buffer(
-                  BufferData, BufferLength, "",
+                  bufferdata, bufferLength, "",
                   type == "gif" ? VImage::option()->set("n", -1) : 0)
                   .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -65,7 +64,7 @@ ArgumentMap Mirror(string type, string *outType, char *BufferData,
   }
 
   void *buf;
-  out.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
+  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/mirror.cc
+++ b/natives/mirror.cc
@@ -63,11 +63,11 @@ ArgumentMap Mirror(const string& type, string& outType, const char* bufferdata, 
     }
   }
 
-  void *buf;
-  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
+  char *buf;
+  out.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/mirror.h
+++ b/natives/mirror.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Mirror(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/motivate.cc
+++ b/natives/motivate.cc
@@ -31,7 +31,7 @@ ArgumentMap Motivate(const string& type, string& outType, const char* bufferdata
   string fontResult =
       findResult != fontPaths.end() ? basePath + findResult->second : "";
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   VImage topImage;
   if (top_text != "") {
     string topText = "<span foreground=\"white\" background=\"black\">" +
@@ -69,7 +69,7 @@ ArgumentMap Motivate(const string& type, string& outType, const char* bufferdata
   }
 
   vector<VImage> img;
-  int height;
+  int height = 0;
   for (int i = 0; i < nPages; i++) {
     VImage img_frame =
         type == "gif" ? in.crop(0, i * pageHeight, width, pageHeight) : in;

--- a/natives/motivate.cc
+++ b/natives/motivate.cc
@@ -5,18 +5,17 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Motivate(string type, string *outType, char *BufferData,
-                     size_t BufferLength, ArgumentMap Arguments,
-                     size_t *DataSize) {
-  string top_text = GetArgument<string>(Arguments, "top");
-  string bottom_text = GetArgument<string>(Arguments, "bottom");
-  string font = GetArgument<string>(Arguments, "font");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Motivate(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string top_text = GetArgument<string>(arguments, "top");
+  string bottom_text = GetArgument<string>(arguments, "bottom");
+  string font = GetArgument<string>(arguments, "font");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -120,8 +119,8 @@ ArgumentMap Motivate(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif" ? VImage::option()->set("dither", 1) : 0);
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif" ? VImage::option()->set("dither", 1) : 0);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/motivate.cc
+++ b/natives/motivate.cc
@@ -117,13 +117,13 @@ ArgumentMap Motivate(const string& type, string& outType, const char* bufferdata
                      .extract_band(0, VImage::option()->set("n", 3));
   final.set(VIPS_META_PAGE_HEIGHT, height);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif" ? VImage::option()->set("dither", 1) : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/motivate.h
+++ b/natives/motivate.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Motivate(string type, string* outType, char* BufferData, size_t BufferLength,
-               ArgumentMap Arguments, size_t* DataSize);

--- a/natives/node/image.cc
+++ b/natives/node/image.cc
@@ -70,10 +70,10 @@ Napi::Value ProcessImage(const Napi::CallbackInfo& info) {
     ArgumentMap outMap;
     if (obj.Has("data")) {
       Napi::Buffer<char> data = obj.Get("data").As<Napi::Buffer<char>>();
-      outMap = FunctionMap.at(command)(type, &outType, data.Data(), data.Length(),
-                                    Arguments, &length);
+      outMap = FunctionMap.at(command)(type, outType, data.Data(), data.Length(),
+                                    Arguments, length);
     } else {
-      outMap = NoInputFunctionMap.at(command)(type, &outType, Arguments, &length);
+      outMap = NoInputFunctionMap.at(command)(type, outType, Arguments, length);
     }
 
     vips_error_clear();

--- a/natives/reddit.cc
+++ b/natives/reddit.cc
@@ -27,7 +27,7 @@ ArgumentMap Reddit(const string& type, string& outType, const char* bufferdata, 
 
   string captionText = "<span foreground=\"white\">" + text + "</span>";
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   VImage textImage = VImage::text(
       captionText.c_str(),
       VImage::option()

--- a/natives/reddit.cc
+++ b/natives/reddit.cc
@@ -5,16 +5,15 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Reddit(string type, string *outType, char *BufferData,
-                   size_t BufferLength, ArgumentMap Arguments,
-                   size_t *DataSize) {
-  string text = GetArgument<string>(Arguments, "caption");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Reddit(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string text = GetArgument<string>(arguments, "caption");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -57,8 +56,8 @@ ArgumentMap Reddit(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/reddit.cc
+++ b/natives/reddit.cc
@@ -54,15 +54,15 @@ ArgumentMap Reddit(const string& type, string& outType, const char* bufferdata, 
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight + watermark.height());
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/reddit.h
+++ b/natives/reddit.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Reddit(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/resize.cc
+++ b/natives/resize.cc
@@ -5,15 +5,15 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Resize(string type, string *outType, char *BufferData,
-             size_t BufferLength, ArgumentMap Arguments, size_t *DataSize) {
-  bool stretch = GetArgumentWithFallback<bool>(Arguments, "stretch", false);
-  bool wide = GetArgumentWithFallback<bool>(Arguments, "wide", false);
+ArgumentMap Resize(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  bool stretch = GetArgumentWithFallback<bool>(arguments, "stretch", false);
+  bool wide = GetArgumentWithFallback<bool>(arguments, "wide", false);
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
 
@@ -48,7 +48,7 @@ ArgumentMap Resize(string type, string *outType, char *BufferData,
   out.set(VIPS_META_PAGE_HEIGHT, finalHeight);
 
   void *buf;
-  out.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
+  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/resize.cc
+++ b/natives/resize.cc
@@ -47,11 +47,11 @@ ArgumentMap Resize(const string& type, string& outType, const char* bufferdata, 
   }
   out.set(VIPS_META_PAGE_HEIGHT, finalHeight);
 
-  void *buf;
-  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
+  char *buf;
+  out.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/resize.cc
+++ b/natives/resize.cc
@@ -23,7 +23,7 @@ ArgumentMap Resize(const string& type, string& outType, const char* bufferdata, 
   int pageHeight = vips_image_get_page_height(in.get_image());
   int nPages = vips_image_get_n_pages(in.get_image());
 
-  int finalHeight;
+  int finalHeight = 0;
   if (stretch) {
     out =
         in.resize(512.0 / (double)width,

--- a/natives/resize.h
+++ b/natives/resize.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Resize(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/reverse.cc
+++ b/natives/reverse.cc
@@ -6,7 +6,7 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Reverse(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+ArgumentMap Reverse([[maybe_unused]] const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
 {
   bool soos = GetArgumentWithFallback<bool>(arguments, "soos", false);
 

--- a/natives/reverse.cc
+++ b/natives/reverse.cc
@@ -6,14 +6,14 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Reverse(string type, string *outType, char *BufferData,
-              size_t BufferLength, ArgumentMap Arguments, size_t *DataSize) {
-  bool soos = GetArgumentWithFallback<bool>(Arguments, "soos", false);
+ArgumentMap Reverse(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  bool soos = GetArgumentWithFallback<bool>(arguments, "soos", false);
 
   VOption *options =
       VImage::option()->set("access", "sequential")->set("n", -1);
 
-  VImage in = VImage::new_from_buffer(BufferData, BufferLength, "", options)
+  VImage in = VImage::new_from_buffer(bufferdata, bufferLength, "", options)
                   .colourspace(VIPS_INTERPRETATION_sRGB);
 
   int width = in.width();
@@ -50,10 +50,10 @@ ArgumentMap Reverse(string type, string *outType, char *BufferData,
   final.set("delay", delays);
 
   void *buf;
-  final.write_to_buffer(".gif", &buf, DataSize,
+  final.write_to_buffer(".gif", &buf, &dataSize,
                         VImage::option()->set("dither", 0));
 
-  *outType = "gif";
+  outType = "gif";
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/reverse.cc
+++ b/natives/reverse.cc
@@ -49,14 +49,14 @@ ArgumentMap Reverse([[maybe_unused]] const string& type, string& outType, const 
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight);
   final.set("delay", delays);
 
-  void *buf;
-  final.write_to_buffer(".gif", &buf, &dataSize,
+  char *buf;
+  final.write_to_buffer(".gif", reinterpret_cast<void**>(&buf), &dataSize,
                         VImage::option()->set("dither", 0));
 
   outType = "gif";
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/reverse.h
+++ b/natives/reverse.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Reverse(string type, string* outType, char* BufferData, size_t BufferLength,
-              ArgumentMap Arguments, size_t* DataSize);

--- a/natives/scott.cc
+++ b/natives/scott.cc
@@ -5,14 +5,14 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Scott(string type, string *outType, char *BufferData, size_t BufferLength,
-            ArgumentMap Arguments, size_t *DataSize) {
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Scott(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -49,8 +49,8 @@ ArgumentMap Scott(string type, string *outType, char *BufferData, size_t BufferL
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif" ? VImage::option()->set("dither", 1) : 0);
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif" ? VImage::option()->set("dither", 1) : 0);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/scott.cc
+++ b/natives/scott.cc
@@ -47,13 +47,13 @@ ArgumentMap Scott(const string& type, string& outType, const char* bufferdata, s
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, 481);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif" ? VImage::option()->set("dither", 1) : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/scott.h
+++ b/natives/scott.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Scott(string type, string* outType, char* BufferData, size_t BufferLength,
-            ArgumentMap Arguments, size_t* DataSize);

--- a/natives/snapchat.cc
+++ b/natives/snapchat.cc
@@ -7,17 +7,16 @@ using namespace vips;
 
 const vector<double> zeroVec178 = {0, 0, 0, 178};
 
-ArgumentMap Snapchat(string type, string *outType, char *BufferData,
-                     size_t BufferLength, ArgumentMap Arguments,
-                     size_t *DataSize) {
-  string caption = GetArgument<string>(Arguments, "caption");
-  float pos = GetArgumentWithFallback<float>(Arguments, "pos", 0.5);
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Snapchat(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string caption = GetArgument<string>(arguments, "caption");
+  float pos = GetArgumentWithFallback<float>(arguments, "pos", 0.5);
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -58,8 +57,8 @@ ArgumentMap Snapchat(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/snapchat.cc
+++ b/natives/snapchat.cc
@@ -29,7 +29,7 @@ ArgumentMap Snapchat(const string& type, string& outType, const char* bufferdata
 
   string font_string = "Helvetica Neue " + to_string(size);
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   VImage textIn = VImage::text(
       ("<span foreground=\"white\" background=\"#000000B2\">" + caption +
        "</span>")

--- a/natives/snapchat.cc
+++ b/natives/snapchat.cc
@@ -55,15 +55,15 @@ ArgumentMap Snapchat(const string& type, string& outType, const char* bufferdata
                           .replicate(1, nPages);
   VImage final = in.composite(replicated, VIPS_BLEND_MODE_OVER);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/snapchat.h
+++ b/natives/snapchat.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Snapchat(string type, string* outType, char* BufferData, size_t BufferLength,
-               ArgumentMap Arguments, size_t* DataSize);

--- a/natives/sonic.cc
+++ b/natives/sonic.cc
@@ -28,11 +28,11 @@ ArgumentMap Sonic([[maybe_unused]] const string& type, string& outType, Argument
   VImage out = bg.composite2(textImage, VIPS_BLEND_MODE_OVER,
                              VImage::option()->set("x", 391)->set("y", 84));
 
-  void *buf;
-  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
+  char *buf;
+  out.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/sonic.cc
+++ b/natives/sonic.cc
@@ -5,7 +5,7 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Sonic(const string& type, string& outType, ArgumentMap arguments, size_t& dataSize)
+ArgumentMap Sonic([[maybe_unused]] const string& type, string& outType, ArgumentMap arguments, size_t& dataSize)
 {
   string text = GetArgument<string>(arguments, "text");
   string basePath = GetArgument<string>(arguments, "basePath");
@@ -13,7 +13,7 @@ ArgumentMap Sonic(const string& type, string& outType, ArgumentMap arguments, si
   string assetPath = basePath + "assets/images/sonic.jpg";
   VImage bg = VImage::new_from_file(assetPath.c_str());
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   VImage textImage =
       VImage::text(
           ("<span foreground=\"white\">" + text + "</span>").c_str(),

--- a/natives/sonic.cc
+++ b/natives/sonic.cc
@@ -5,10 +5,10 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Sonic(string type, string *outType, ArgumentMap Arguments,
-            size_t *DataSize) {
-  string text = GetArgument<string>(Arguments, "text");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Sonic(const string& type, string& outType, ArgumentMap arguments, size_t& dataSize)
+{
+  string text = GetArgument<string>(arguments, "text");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   string assetPath = basePath + "assets/images/sonic.jpg";
   VImage bg = VImage::new_from_file(assetPath.c_str());
@@ -29,7 +29,7 @@ ArgumentMap Sonic(string type, string *outType, ArgumentMap Arguments,
                              VImage::option()->set("x", 391)->set("y", 84));
 
   void *buf;
-  out.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
+  out.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/sonic.h
+++ b/natives/sonic.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Sonic(string type, string *outType, ArgumentMap Arguments, size_t *DataSize);

--- a/natives/speed.cc
+++ b/natives/speed.cc
@@ -48,7 +48,7 @@ ArgumentMap Speed([[maybe_unused]] const string& type, [[maybe_unused]] string& 
   char *fileData = reinterpret_cast<char*>(malloc(bufferLength));
   memcpy(fileData, bufferdata, bufferLength);
 
-  char *match = static_cast<char*>("\x00\x21\xF9\x04");
+  char *match = const_cast<char*>("\x00\x21\xF9\x04");
 
   vector<uint16_t> old_delays;
   bool removeFrames = false;
@@ -56,27 +56,27 @@ ArgumentMap Speed([[maybe_unused]] const string& type, [[maybe_unused]] string& 
 
   // int amount = 0;
 
-  lastPos = (char *)memchr(fileData, '\x00', bufferLength);
+  lastPos = reinterpret_cast<char*>(memchr(fileData, '\x00', bufferLength));
   while (lastPos != NULL) {
     if (memcmp(lastPos, match, 4) != 0) {
-      lastPos = (char *)memchr(lastPos + 1, '\x00',
-                               (bufferLength - (lastPos - fileData)) - 1);
+      lastPos = reinterpret_cast<char*>(memchr(lastPos + 1, '\x00',
+                               (bufferLength - (lastPos - fileData)) - 1));
       continue;
     }
     //++amount;
     uint16_t old_delay;
     memcpy(&old_delay, lastPos + 5, 2);
     old_delays.push_back(old_delay);
-    lastPos = (char *)memchr(lastPos + 1, '\x00',
-                             (bufferLength - (lastPos - fileData)) - 1);
+    lastPos = reinterpret_cast<char*>(memchr(lastPos + 1, '\x00',
+                             (bufferLength - (lastPos - fileData)) - 1));
   }
 
   int currentFrame = 0;
-  lastPos = (char *)memchr(fileData, '\x00', bufferLength);
+  lastPos = reinterpret_cast<char*>(memchr(fileData, '\x00', bufferLength));
   while (lastPos != NULL) {
     if (memcmp(lastPos, match, 4) != 0) {
-      lastPos = (char *)memchr(lastPos + 1, '\x00',
-                               (bufferLength - (lastPos - fileData)) - 1);
+      lastPos = reinterpret_cast<char*>(memchr(lastPos + 1, '\x00',
+                               (bufferLength - (lastPos - fileData)) - 1));
       continue;
     }
     uint16_t new_delay = slow ? old_delays[currentFrame] * speed
@@ -88,8 +88,8 @@ ArgumentMap Speed([[maybe_unused]] const string& type, [[maybe_unused]] string& 
 
     memset16(lastPos + 5, new_delay, 1);
 
-    lastPos = (char *)memchr(lastPos + 1, '\x00',
-                             (bufferLength - (lastPos - fileData)) - 1);
+    lastPos = reinterpret_cast<char*>(memchr(lastPos + 1, '\x00',
+                             (bufferLength - (lastPos - fileData)) - 1));
     ++currentFrame;
   }
 

--- a/natives/speed.cc
+++ b/natives/speed.cc
@@ -34,10 +34,10 @@ char *vipsRemove(const char *data, size_t length, size_t& dataSize, int speed) {
   VImage out = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   out.set(VIPS_META_PAGE_HEIGHT, pageHeight);
 
-  void *buf;
-  out.write_to_buffer(".gif", &buf, &dataSize);
+  char *buf;
+  out.write_to_buffer(".gif", reinterpret_cast<void**>(&buf), &dataSize);
 
-  return (char *)buf;
+  return buf;
 }
 
 ArgumentMap Speed([[maybe_unused]] const string& type, [[maybe_unused]] string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
@@ -45,10 +45,10 @@ ArgumentMap Speed([[maybe_unused]] const string& type, [[maybe_unused]] string& 
   bool slow = GetArgumentWithFallback<bool>(arguments, "slow", false);
   int speed = GetArgumentWithFallback<int>(arguments, "speed", 2);
 
-  char *fileData = (char *)malloc(bufferLength);
+  char *fileData = reinterpret_cast<char*>(malloc(bufferLength));
   memcpy(fileData, bufferdata, bufferLength);
 
-  char *match = (char *)"\x00\x21\xF9\x04";
+  char *match = static_cast<char*>("\x00\x21\xF9\x04");
 
   vector<uint16_t> old_delays;
   bool removeFrames = false;

--- a/natives/speed.cc
+++ b/natives/speed.cc
@@ -40,7 +40,7 @@ char *vipsRemove(const char *data, size_t length, size_t& dataSize, int speed) {
   return (char *)buf;
 }
 
-ArgumentMap Speed([[maybe_unused]] const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+ArgumentMap Speed([[maybe_unused]] const string& type, [[maybe_unused]] string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
 {
   bool slow = GetArgumentWithFallback<bool>(arguments, "slow", false);
   int speed = GetArgumentWithFallback<int>(arguments, "speed", 2);

--- a/natives/speed.cc
+++ b/natives/speed.cc
@@ -15,7 +15,7 @@ void *memset16(void *m, uint16_t val, size_t count) {
   return m;
 }
 
-char *vipsRemove(char *data, size_t length, size_t *DataSize, int speed) {
+char *vipsRemove(const char *data, size_t length, size_t& dataSize, int speed) {
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in = VImage::new_from_buffer(data, length, "", options->set("n", -1))
@@ -35,18 +35,18 @@ char *vipsRemove(char *data, size_t length, size_t *DataSize, int speed) {
   out.set(VIPS_META_PAGE_HEIGHT, pageHeight);
 
   void *buf;
-  out.write_to_buffer(".gif", &buf, DataSize);
+  out.write_to_buffer(".gif", &buf, &dataSize);
 
   return (char *)buf;
 }
 
-ArgumentMap Speed([[maybe_unused]] string type, string *outType, char *BufferData,
-            size_t BufferLength, ArgumentMap Arguments, size_t *DataSize) {
-  bool slow = GetArgumentWithFallback<bool>(Arguments, "slow", false);
-  int speed = GetArgumentWithFallback<int>(Arguments, "speed", 2);
+ArgumentMap Speed([[maybe_unused]] const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  bool slow = GetArgumentWithFallback<bool>(arguments, "slow", false);
+  int speed = GetArgumentWithFallback<int>(arguments, "speed", 2);
 
-  char *fileData = (char *)malloc(BufferLength);
-  memcpy(fileData, BufferData, BufferLength);
+  char *fileData = (char *)malloc(bufferLength);
+  memcpy(fileData, bufferdata, bufferLength);
 
   char *match = (char *)"\x00\x21\xF9\x04";
 
@@ -56,11 +56,11 @@ ArgumentMap Speed([[maybe_unused]] string type, string *outType, char *BufferDat
 
   // int amount = 0;
 
-  lastPos = (char *)memchr(fileData, '\x00', BufferLength);
+  lastPos = (char *)memchr(fileData, '\x00', bufferLength);
   while (lastPos != NULL) {
     if (memcmp(lastPos, match, 4) != 0) {
       lastPos = (char *)memchr(lastPos + 1, '\x00',
-                               (BufferLength - (lastPos - fileData)) - 1);
+                               (bufferLength - (lastPos - fileData)) - 1);
       continue;
     }
     //++amount;
@@ -68,15 +68,15 @@ ArgumentMap Speed([[maybe_unused]] string type, string *outType, char *BufferDat
     memcpy(&old_delay, lastPos + 5, 2);
     old_delays.push_back(old_delay);
     lastPos = (char *)memchr(lastPos + 1, '\x00',
-                             (BufferLength - (lastPos - fileData)) - 1);
+                             (bufferLength - (lastPos - fileData)) - 1);
   }
 
   int currentFrame = 0;
-  lastPos = (char *)memchr(fileData, '\x00', BufferLength);
+  lastPos = (char *)memchr(fileData, '\x00', bufferLength);
   while (lastPos != NULL) {
     if (memcmp(lastPos, match, 4) != 0) {
       lastPos = (char *)memchr(lastPos + 1, '\x00',
-                               (BufferLength - (lastPos - fileData)) - 1);
+                               (bufferLength - (lastPos - fileData)) - 1);
       continue;
     }
     uint16_t new_delay = slow ? old_delays[currentFrame] * speed
@@ -89,14 +89,14 @@ ArgumentMap Speed([[maybe_unused]] string type, string *outType, char *BufferDat
     memset16(lastPos + 5, new_delay, 1);
 
     lastPos = (char *)memchr(lastPos + 1, '\x00',
-                             (BufferLength - (lastPos - fileData)) - 1);
+                             (bufferLength - (lastPos - fileData)) - 1);
     ++currentFrame;
   }
 
   if (removeFrames) {
-    fileData = vipsRemove(BufferData, BufferLength, DataSize, speed);
+    fileData = vipsRemove(bufferdata, bufferLength, dataSize, speed);
   } else {
-    *DataSize = BufferLength;
+    dataSize = bufferLength;
   }
 
   ArgumentMap output;

--- a/natives/speed.h
+++ b/natives/speed.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Speed(string type, string* outType, char* BufferData, size_t BufferLength,
-            ArgumentMap Arguments, size_t* DataSize);

--- a/natives/spin.cc
+++ b/natives/spin.cc
@@ -10,9 +10,9 @@
 using namespace std;
 using namespace Magick;
 
-ArgumentMap Spin(string type, string *outType, char *BufferData, size_t BufferLength,
-           [[maybe_unused]] ArgumentMap Arguments, size_t *DataSize) {
-  int delay = GetArgumentWithFallback<int>(Arguments, "delay", 0);
+ArgumentMap Spin(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
+  int delay = GetArgumentWithFallback<int>(arguments, "delay", 0);
 
   Blob blob;
 
@@ -20,7 +20,7 @@ ArgumentMap Spin(string type, string *outType, char *BufferData, size_t BufferLe
   list<Image> coalesced;
   list<Image> mid;
   try {
-    readImages(&frames, Blob(BufferData, BufferLength));
+    readImages(&frames, Blob(bufferdata, bufferLength));
   } catch (Magick::WarningCoder &warning) {
     cerr << "Coder Warning: " << warning.what() << endl;
   } catch (Magick::Warning &warning) {
@@ -64,11 +64,11 @@ ArgumentMap Spin(string type, string *outType, char *BufferData, size_t BufferLe
 
   writeImages(mid.begin(), mid.end(), &blob);
 
-  *outType = "gif";
-  *DataSize = blob.length();
+  outType = "gif";
+  dataSize = blob.length();
 
-  char *data = (char *)malloc(*DataSize);
-  memcpy(data, blob.data(), *DataSize);
+  char *data = (char *)malloc(dataSize);
+  memcpy(data, blob.data(), dataSize);
   
   ArgumentMap output;
   output["buf"] = data;

--- a/natives/spin.cc
+++ b/natives/spin.cc
@@ -67,7 +67,7 @@ ArgumentMap Spin(const string& type, string& outType, const char* bufferdata, si
   outType = "gif";
   dataSize = blob.length();
 
-  char *data = (char *)malloc(dataSize);
+  char *data = reinterpret_cast<char*>(malloc(dataSize));
   memcpy(data, blob.data(), dataSize);
   
   ArgumentMap output;

--- a/natives/spin.h
+++ b/natives/spin.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Spin(string type, string* outType, char* BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t* DataSize);

--- a/natives/spotify.cc
+++ b/natives/spotify.cc
@@ -55,15 +55,15 @@ ArgumentMap Spotify(const string& type, string& outType, const char* bufferdata,
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight + watermark.height());
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/spotify.cc
+++ b/natives/spotify.cc
@@ -27,7 +27,7 @@ ArgumentMap Spotify(const string& type, string& outType, const char* bufferdata,
 
   string captionText = "<span foreground=\"black\">" + text + "</span>";
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   VImage textImage = VImage::text(
       captionText.c_str(),
       VImage::option()

--- a/natives/spotify.cc
+++ b/natives/spotify.cc
@@ -5,16 +5,15 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Spotify(string type, string *outType, char *BufferData,
-                    size_t BufferLength, ArgumentMap Arguments,
-                    size_t *DataSize) {
-  string text = GetArgument<string>(Arguments, "caption");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Spotify(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string text = GetArgument<string>(arguments, "caption");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -58,8 +57,8 @@ ArgumentMap Spotify(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/spotify.h
+++ b/natives/spotify.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Spotify(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/squish.cc
+++ b/natives/squish.cc
@@ -7,12 +7,11 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Squish(string type, string *outType, char *BufferData,
-             size_t BufferLength, [[maybe_unused]] ArgumentMap Arguments,
-             size_t *DataSize) {
+ArgumentMap Squish(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
   VImage in =
       VImage::new_from_buffer(
-          BufferData, BufferLength, "",
+          bufferdata, bufferLength, "",
           type == "gif" ? VImage::option()->set("n", -1)->set("access", "sequential")
                         : 0)
           .colourspace(VIPS_INTERPRETATION_sRGB);
@@ -42,9 +41,9 @@ ArgumentMap Squish(string type, string *outType, char *BufferData,
   }
 
   void *buf;
-  final.write_to_buffer(".gif", &buf, DataSize);
+  final.write_to_buffer(".gif", &buf, &dataSize);
 
-  *outType = "gif";
+  outType = "gif";
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/squish.cc
+++ b/natives/squish.cc
@@ -40,13 +40,13 @@ ArgumentMap Squish(const string& type, string& outType, const char* bufferdata, 
     final.set("delay", delay);
   }
 
-  void *buf;
-  final.write_to_buffer(".gif", &buf, &dataSize);
+  char *buf;
+  final.write_to_buffer(".gif", reinterpret_cast<void**>(&buf), &dataSize);
 
   outType = "gif";
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/squish.h
+++ b/natives/squish.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Squish(string type, string* outType, char* BufferData, size_t BufferLength,
-             ArgumentMap Arguments, size_t* DataSize);

--- a/natives/swirl.cc
+++ b/natives/swirl.cc
@@ -67,11 +67,11 @@ ArgumentMap Swirl(const string& type, string& outType, const char* bufferdata, s
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight);
 
-  void *buf;
-  final.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
+  char *buf;
+  final.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/swirl.cc
+++ b/natives/swirl.cc
@@ -5,10 +5,10 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Swirl(string type, string *outType, char *BufferData, size_t BufferLength,
-            [[maybe_unused]] ArgumentMap Arguments, size_t *DataSize) {
+ArgumentMap Swirl(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? VImage::option()->set("n", -1) : 0)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -68,7 +68,7 @@ ArgumentMap Swirl(string type, string *outType, char *BufferData, size_t BufferL
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight);
 
   void *buf;
-  final.write_to_buffer(("." + *outType).c_str(), &buf, DataSize);
+  final.write_to_buffer(("." + outType).c_str(), &buf, &dataSize);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/swirl.h
+++ b/natives/swirl.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Swirl(string type, string* outType, char* BufferData, size_t BufferLength,
-            ArgumentMap Arguments, size_t* DataSize);

--- a/natives/tile.cc
+++ b/natives/tile.cc
@@ -5,11 +5,9 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Tile(string type, string *outType, char *BufferData,
-                 size_t BufferLength, [[maybe_unused]] ArgumentMap Arguments,
-                 size_t *DataSize) {
+ArgumentMap Tile(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize) {
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? VImage::option()->set("n", -1) : 0)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -35,8 +33,8 @@ ArgumentMap Tile(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif" ? VImage::option()->set("reoptimise", 1) : 0);
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif" ? VImage::option()->set("reoptimise", 1) : 0);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/tile.cc
+++ b/natives/tile.cc
@@ -32,13 +32,13 @@ ArgumentMap Tile(const string& type, string& outType, const char* bufferdata, si
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, finalHeight);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif" ? VImage::option()->set("reoptimise", 1) : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/tile.cc
+++ b/natives/tile.cc
@@ -5,7 +5,8 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Tile(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize) {
+ArgumentMap Tile(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
   VImage in =
       VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? VImage::option()->set("n", -1) : 0)
@@ -17,7 +18,7 @@ ArgumentMap Tile(const string& type, string& outType, const char* bufferdata, si
   int nPages = vips_image_get_n_pages(in.get_image());
 
   vector<VImage> img;
-  int finalHeight;
+  int finalHeight = 0;
   for (int i = 0; i < nPages; i++) {
     VImage img_frame =
         type == "gif" ? in.crop(0, i * pageHeight, width, pageHeight) : in;

--- a/natives/tile.h
+++ b/natives/tile.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Tile(string type, string* outType, char* BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t* DataSize);

--- a/natives/togif.cc
+++ b/natives/togif.cc
@@ -9,7 +9,7 @@ ArgumentMap ToGif(const string& type, string& outType, const char* bufferdata, s
 {
   if (type == "gif") {
     dataSize = bufferLength;
-    char *data = (char *)malloc(bufferLength);
+    char *data = reinterpret_cast<char*>(malloc(bufferLength));
     memcpy(data, bufferdata, bufferLength);
 
     ArgumentMap output;

--- a/natives/togif.cc
+++ b/natives/togif.cc
@@ -5,12 +5,12 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap ToGif(string type, string *outType, char *BufferData, size_t BufferLength,
-            [[maybe_unused]] ArgumentMap Arguments, size_t *DataSize) {
+ArgumentMap ToGif(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
   if (type == "gif") {
-    *DataSize = BufferLength;
-    char *data = (char *)malloc(BufferLength);
-    memcpy(data, BufferData, BufferLength);
+    dataSize = bufferLength;
+    char *data = (char *)malloc(bufferLength);
+    memcpy(data, bufferdata, bufferLength);
 
     ArgumentMap output;
     output["buf"] = data;
@@ -21,12 +21,12 @@ ArgumentMap ToGif(string type, string *outType, char *BufferData, size_t BufferL
     VOption *options = VImage::option()->set("access", "sequential");
 
     VImage in = VImage::new_from_buffer(
-        BufferData, BufferLength, "",
+        bufferdata, bufferLength, "",
         type == "webp" ? options->set("n", -1) : options);
 
     void *buf;
-    in.write_to_buffer(".gif", &buf, DataSize);
-    *outType = "gif";
+    in.write_to_buffer(".gif", &buf, &dataSize);
+    outType = "gif";
 
     ArgumentMap output;
     output["buf"] = (char *)buf;

--- a/natives/togif.cc
+++ b/natives/togif.cc
@@ -24,12 +24,12 @@ ArgumentMap ToGif(const string& type, string& outType, const char* bufferdata, s
         bufferdata, bufferLength, "",
         type == "webp" ? options->set("n", -1) : options);
 
-    void *buf;
-    in.write_to_buffer(".gif", &buf, &dataSize);
+    char *buf;
+    in.write_to_buffer(".gif", reinterpret_cast<void**>(&buf), &dataSize);
     outType = "gif";
 
     ArgumentMap output;
-    output["buf"] = (char *)buf;
+    output["buf"] = buf;
 
     return output;
   }

--- a/natives/togif.h
+++ b/natives/togif.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap ToGif(string type, string* outType, char* BufferData, size_t BufferLength,
-            ArgumentMap Arguments, size_t* DataSize);

--- a/natives/uncanny.cc
+++ b/natives/uncanny.cc
@@ -35,7 +35,7 @@ ArgumentMap Uncanny(const string& type, string& outType, const char* bufferdata,
   string fontResult =
       findResult != fontPaths.end() ? basePath + findResult->second : "";
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   VImage text = VImage::text(captionText.c_str(),
                              VImage::option()
                                  ->set("rgba", true)

--- a/natives/uncanny.cc
+++ b/natives/uncanny.cc
@@ -5,19 +5,18 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Uncanny(string type, string *outType, char *BufferData,
-                    size_t BufferLength, ArgumentMap Arguments,
-                    size_t *DataSize) {
-  string caption = GetArgument<string>(Arguments, "caption");
-  string caption2 = GetArgument<string>(Arguments, "caption2");
-  string font = GetArgument<string>(Arguments, "font");
-  string path = GetArgument<string>(Arguments, "path");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Uncanny(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string caption = GetArgument<string>(arguments, "caption");
+  string caption2 = GetArgument<string>(arguments, "caption2");
+  string font = GetArgument<string>(arguments, "font");
+  string path = GetArgument<string>(arguments, "path");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB)
           .extract_band(0, VImage::option()->set("n", 3));
@@ -91,8 +90,8 @@ ArgumentMap Uncanny(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif" ? VImage::option()->set("reoptimise", 1) : 0);
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif" ? VImage::option()->set("reoptimise", 1) : 0);
 
   ArgumentMap output;
   output["buf"] = (char *)buf;

--- a/natives/uncanny.cc
+++ b/natives/uncanny.cc
@@ -88,13 +88,13 @@ ArgumentMap Uncanny(const string& type, string& outType, const char* bufferdata,
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, 720);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif" ? VImage::option()->set("reoptimise", 1) : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/uncanny.h
+++ b/natives/uncanny.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Uncanny(string type, string* outType, char* BufferData, size_t BufferLength,
-              ArgumentMap Arguments, size_t* DataSize);

--- a/natives/uncaption.cc
+++ b/natives/uncaption.cc
@@ -6,13 +6,13 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Uncaption(string type, string *outType, char *BufferData,
-                size_t BufferLength, ArgumentMap Arguments, size_t *DataSize) {
-  float tolerance = GetArgumentWithFallback<float>(Arguments, "tolerance", 0.5);
+ArgumentMap Uncaption(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  float tolerance = GetArgumentWithFallback<float>(arguments, "tolerance", 0.5);
 
   VImage in =
       VImage::new_from_buffer(
-          BufferData, BufferLength, "",
+          bufferdata, bufferLength, "",
           type == "gif" ? VImage::option()->set("n", -1)->set("access", "sequential")
                         : 0)
           .colourspace(VIPS_INTERPRETATION_sRGB);
@@ -43,8 +43,8 @@ ArgumentMap Uncaption(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/uncaption.cc
+++ b/natives/uncaption.cc
@@ -41,15 +41,15 @@ ArgumentMap Uncaption(const string& type, string& outType, const char* bufferdat
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, newHeight);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/uncaption.h
+++ b/natives/uncaption.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Uncaption(string type, string* outType, char* BufferData, size_t BufferLength,
-                ArgumentMap Arguments, size_t* DataSize);

--- a/natives/wall.cc
+++ b/natives/wall.cc
@@ -53,7 +53,7 @@ ArgumentMap Wall([[maybe_unused]] const string& type, string& outType, const cha
 
   dataSize = blob.length();
 
-  char *data = (char *)malloc(dataSize);
+  char *data = reinterpret_cast<char*>(malloc(dataSize));
   memcpy(data, blob.data(), dataSize);
 
   ArgumentMap output;

--- a/natives/wall.cc
+++ b/natives/wall.cc
@@ -10,7 +10,7 @@
 using namespace std;
 using namespace Magick;
 
-ArgumentMap Wall(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+ArgumentMap Wall([[maybe_unused]] const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
 {
   Blob blob;
 

--- a/natives/wall.cc
+++ b/natives/wall.cc
@@ -10,15 +10,15 @@
 using namespace std;
 using namespace Magick;
 
-ArgumentMap Wall(string type, string *outType, char *BufferData, size_t BufferLength,
-           [[maybe_unused]] ArgumentMap Arguments, size_t *DataSize) {
+ArgumentMap Wall(const string& type, string& outType, const char* bufferdata, size_t bufferLength, [[maybe_unused]] ArgumentMap arguments, size_t& dataSize)
+{
   Blob blob;
 
   list<Image> frames;
   list<Image> coalesced;
   list<Image> mid;
   try {
-    readImages(&frames, Blob(BufferData, BufferLength));
+    readImages(&frames, Blob(bufferdata, bufferLength));
   } catch (Magick::WarningCoder &warning) {
     cerr << "Coder Warning: " << warning.what() << endl;
   } catch (Magick::Warning &warning) {
@@ -36,13 +36,13 @@ ArgumentMap Wall(string type, string *outType, char *BufferData, size_t BufferLe
                             128, 0, 140, 60, 128, 128, 140, 140};
     image.distort(Magick::PerspectiveDistortion, 16, arguments);
     image.scale(Geometry("800x800>"));
-    image.magick(*outType);
+    image.magick(outType);
     mid.push_back(image);
   }
 
   optimizeTransparency(mid.begin(), mid.end());
 
-  if (*outType == "gif") {
+  if (outType == "gif") {
     for (Image &image : mid) {
       image.quantizeDitherMethod(FloydSteinbergDitherMethod);
       image.quantize();
@@ -51,10 +51,10 @@ ArgumentMap Wall(string type, string *outType, char *BufferData, size_t BufferLe
 
   writeImages(mid.begin(), mid.end(), &blob);
 
-  *DataSize = blob.length();
+  dataSize = blob.length();
 
-  char *data = (char *)malloc(*DataSize);
-  memcpy(data, blob.data(), *DataSize);
+  char *data = (char *)malloc(dataSize);
+  memcpy(data, blob.data(), dataSize);
 
   ArgumentMap output;
   output["buf"] = data;

--- a/natives/wall.h
+++ b/natives/wall.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Wall(string type, string* outType, char* BufferData, size_t BufferLength,
-           ArgumentMap Arguments, size_t* DataSize);

--- a/natives/watermark.cc
+++ b/natives/watermark.cc
@@ -6,29 +6,29 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Watermark(string type, string *outType, char *BufferData,
-                size_t BufferLength, ArgumentMap Arguments, size_t *DataSize) {
-  string water = GetArgument<string>(Arguments, "water");
-  int gravity = GetArgument<int>(Arguments, "gravity");
+ArgumentMap Watermark(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string water = GetArgument<string>(arguments, "water");
+  int gravity = GetArgument<int>(arguments, "gravity");
 
-  bool resize = GetArgumentWithFallback<bool>(Arguments, "resize", false);
+  bool resize = GetArgumentWithFallback<bool>(arguments, "resize", false);
 
-  float yscale = GetArgumentWithFallback<float>(Arguments, "yscale", false);
+  float yscale = GetArgumentWithFallback<float>(arguments, "yscale", false);
 
-  bool append = GetArgumentWithFallback<bool>(Arguments, "append", false);
+  bool append = GetArgumentWithFallback<bool>(arguments, "append", false);
 
-  bool alpha = GetArgumentWithFallback<bool>(Arguments, "alpha", false);
-  bool flipX = GetArgumentWithFallback<bool>(Arguments, "flipX", false);
-  bool flipY = GetArgumentWithFallback<bool>(Arguments, "flipY", false);
+  bool alpha = GetArgumentWithFallback<bool>(arguments, "alpha", false);
+  bool flipX = GetArgumentWithFallback<bool>(arguments, "flipX", false);
+  bool flipY = GetArgumentWithFallback<bool>(arguments, "flipY", false);
 
-  bool mc = MapContainsKey(Arguments, "mc");
+  bool mc = MapContainsKey(arguments, "mc");
 
-  string basePath = GetArgument<string>(Arguments, "basePath");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -126,8 +126,8 @@ ArgumentMap Watermark(string type, string *outType, char *BufferData,
           bg = frameAlpha.new_from_image({0, 0, 0}).copy(VImage::option()->set(
               "interpretation", VIPS_INTERPRETATION_sRGB));
           frame = bg.bandjoin(frameAlpha);
-          if (*outType == "jpg" || *outType == "jpeg") {
-            *outType = "png";
+          if (outType == "jpg" || outType == "jpeg") {
+            outType = "png";
           }
         }
         VImage content =
@@ -150,8 +150,8 @@ ArgumentMap Watermark(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/watermark.cc
+++ b/natives/watermark.cc
@@ -21,7 +21,7 @@ ArgumentMap Watermark(string type, string *outType, char *BufferData,
   bool flipX = GetArgumentWithFallback<bool>(Arguments, "flipX", false);
   bool flipY = GetArgumentWithFallback<bool>(Arguments, "flipY", false);
 
-  bool mc = MAP_HAS(Arguments, "mc");
+  bool mc = MapContainsKey(Arguments, "mc");
 
   string basePath = GetArgument<string>(Arguments, "basePath");
 

--- a/natives/watermark.cc
+++ b/natives/watermark.cc
@@ -148,15 +148,15 @@ ArgumentMap Watermark(const string& type, string& outType, const char* bufferdat
   VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
   final.set(VIPS_META_PAGE_HEIGHT, pageHeight + addedHeight);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/watermark.h
+++ b/natives/watermark.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Watermark(string type, string* outType, char* BufferData, size_t BufferLength,
-                ArgumentMap Arguments, size_t* DataSize);

--- a/natives/whisper.cc
+++ b/natives/whisper.cc
@@ -30,7 +30,7 @@ ArgumentMap Whisper(const string& type, string& outType, const char* bufferdata,
       VImage::gaussmat(rad / 2, 0.1, VImage::option()->set("separable", true)) *
       8;
 
-  loadFonts(basePath);
+  LoadFonts(basePath);
   VImage textIn = VImage::text(
       ("<span foreground=\"white\">" + caption + "</span>").c_str(),
       VImage::option()

--- a/natives/whisper.cc
+++ b/natives/whisper.cc
@@ -5,16 +5,15 @@
 using namespace std;
 using namespace vips;
 
-ArgumentMap Whisper(string type, string *outType, char *BufferData,
-                    size_t BufferLength, ArgumentMap Arguments,
-                    size_t *DataSize) {
-  string caption = GetArgument<string>(Arguments, "caption");
-  string basePath = GetArgument<string>(Arguments, "basePath");
+ArgumentMap Whisper(const string& type, string& outType, const char* bufferdata, size_t bufferLength, ArgumentMap arguments, size_t& dataSize)
+{
+  string caption = GetArgument<string>(arguments, "caption");
+  string basePath = GetArgument<string>(arguments, "basePath");
 
   VOption *options = VImage::option()->set("access", "sequential");
 
   VImage in =
-      VImage::new_from_buffer(BufferData, BufferLength, "",
+      VImage::new_from_buffer(bufferdata, bufferLength, "",
                               type == "gif" ? options->set("n", -1) : options)
           .colourspace(VIPS_INTERPRETATION_sRGB);
   if (!in.has_alpha()) in = in.bandjoin(255);
@@ -59,8 +58,8 @@ ArgumentMap Whisper(string type, string *outType, char *BufferData,
 
   void *buf;
   final.write_to_buffer(
-      ("." + *outType).c_str(), &buf, DataSize,
-      *outType == "gif"
+      ("." + outType).c_str(), &buf, &dataSize,
+      outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 

--- a/natives/whisper.cc
+++ b/natives/whisper.cc
@@ -56,15 +56,15 @@ ArgumentMap Whisper(const string& type, string& outType, const char* bufferdata,
                           .replicate(1, nPages);
   VImage final = in.composite(replicated, VIPS_BLEND_MODE_OVER);
 
-  void *buf;
+  char *buf;
   final.write_to_buffer(
-      ("." + outType).c_str(), &buf, &dataSize,
+      ("." + outType).c_str(), reinterpret_cast<void**>(&buf), &dataSize,
       outType == "gif"
           ? VImage::option()->set("dither", 0)->set("reoptimise", 1)
           : 0);
 
   ArgumentMap output;
-  output["buf"] = (char *)buf;
+  output["buf"] = buf;
 
   return output;
 }

--- a/natives/whisper.h
+++ b/natives/whisper.h
@@ -1,8 +1,0 @@
-#pragma once
-
-#include "common.h"
-
-using std::string;
-
-ArgumentMap Whisper(string type, string* outType, char* BufferData, size_t BufferLength,
-              ArgumentMap Arguments, size_t* DataSize);


### PR DESCRIPTION
- moved all Image command ``.h`` files to a new file, ``commands.h``
- added new (hopefully temporary) preprocessor macros ``declare_input_func`` and ``declare_noinput_func`` to make adding functions easier
- Argument list for Image commands updated to be safer and reflect their nature better
     - ``string type`` -> ``const string& type``
     - ``string* outType`` -> ``string& outType``
     - ``char *BufferData`` -> ``const char* bufferData``
     - ``size_t *DataSize`` -> ``size_t& dataSize``
- moved ``LoadFonts`` and ``MapContainsKey`` to new ``common.cc`` to prevent any compilation unit weirdness and executable bloating
- fixed all C++ build warnings
- removed more completely unnecessary/unused variables and functions that cluttered the global namespace 
- Added Kate to the gitignore because I use Kate and KDevelop