### PR TITLE
fix DM commands not working in certain cases

### DIFF
--- a/classes/command.js
+++ b/classes/command.js
@@ -14,7 +14,7 @@ class Command {
       this.guild = options.message.guild;
       this.author = options.message.author;
       this.member = options.message.member;
-      this.permissions = this.channel ? this.channel.permissionsOf(client.user.id.toString()) : Constants.AllTextPermissions;
+      this.permissions = this.channel?.permissionsOf?.(client.user.id) ?? Constants.AllTextPermissions;
       this.content = options.content;
       this.options = options.specialArgs;
       this.reference = {

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -25,7 +25,7 @@ export default async (client, message) => {
       return;
     }
   }
-  if (message.guildID && !permChannel.permissionsOf(client.user.id.toString()).has("SEND_MESSAGES")) return;
+  if (message.guildID && !permChannel.permissionsOf(client.user.id).has("SEND_MESSAGES")) return;
 
   if (!mentionRegex) mentionRegex = new RegExp(`^<@!?${client.user.id}> `);
 

--- a/utils/imagedetect.js
+++ b/utils/imagedetect.js
@@ -146,7 +146,8 @@ export default async (client, cmdMessage, interaction, options, extraReturnTypes
   if (!singleMessage) {
     // if there aren't any replies or interaction attachments then iterate over the last few messages in the channel
     const channel = (interaction ? interaction : cmdMessage).channel ?? await client.rest.channels.get((interaction ? interaction : cmdMessage).channelID);
-    if (!channel.permissionsOf(client.user.id.toString()).has("VIEW_CHANNEL")) return;
+    const perms = channel.permissionsOf?.(client.user.id);
+    if (perms && !perms.has("VIEW_CHANNEL")) return;
     const messages = await channel.getMessages();
     // iterate over each message
     for (const message of messages) {

--- a/utils/soundplayer.js
+++ b/utils/soundplayer.js
@@ -51,12 +51,12 @@ export async function play(client, soundUrl, options) {
   if (!manager) return { content: "The sound commands are still starting up!", flags: 64 };
   if (!options.guild) return { content: "This command only works in servers!", flags: 64 };
   if (!options.member.voiceState) return { content: "You need to be in a voice channel first!", flags: 64 };
-  if (!options.guild.permissionsOf(client.user.id.toString()).has("CONNECT")) return { content: "I can't join this voice channel!", flags: 64 };
+  if (!options.guild.permissionsOf(client.user.id).has("CONNECT")) return { content: "I can't join this voice channel!", flags: 64 };
   const voiceChannel = options.guild.channels.get(options.member.voiceState.channelID) ?? await client.rest.channels.get(options.member.voiceState.channelID).catch(e => {
     logger.warn(`Failed to get a voice channel: ${e}`);
   });
   if (!voiceChannel) return { content: "I can't join this voice channel! Make sure I have the right permissions.", flags: 64 };
-  if (!voiceChannel.permissionsOf(client.user.id.toString()).has("CONNECT")) return { content: "I don't have permission to join this voice channel!", flags: 64 };
+  if (!voiceChannel.permissionsOf(client.user.id).has("CONNECT")) return { content: "I don't have permission to join this voice channel!", flags: 64 };
   const node = manager.options.nodeResolver(manager.nodes);
   let response;
   try {


### PR DESCRIPTION
oceanic PrivateChannel does not have a permissionsOf method, so attempting to run commands in DMs would sometimes fail.

also remove some unecessary toString() calls
