### PR TITLE
Fix spoiler detection on embeds

### DIFF
--- a/utils/imagedetect.js
+++ b/utils/imagedetect.js
@@ -112,7 +112,7 @@ const checkImages = async (message, extraReturnTypes, video, sticker) => {
     if (message.embeds.length !== 0) {
       let hasSpoiler = false;
       if (message.embeds[0].url && message.content) {
-        const spoilerRegex = new RegExp(`(?:\s|^)\|\|(\s+${message.embeds[0].url}\s+)\|\|`);
+        const spoilerRegex = /\|\|.*https?:\/\/.*\|\|/s;
         hasSpoiler = spoilerRegex.test(message.content);
       }
       // embeds can vary in types, we check for tenor gifs first


### PR DESCRIPTION
The current spoiler detection for embeds interprets all embeds as spoilers, every time.

```js
let hasSpoiler = false;
if (message.embeds[0].url && message.content) {
  const spoilerRegex = new RegExp(`(?:\s|^)\|\|(\s+${message.embeds[0].url}\s+)\|\|`);
  hasSpoiler = spoilerRegex.test(message.content);
}
```

This is because the escapes disappear when the string is parsed, so the actual regex code ends up being something like `(?:s|^)||(s+https://example.com/s+)||`, which matches every string because of the unescaped `|` characters. And the URL parsed by Discord may contain `||` at the end.

But it seems like the Discord client marks *all* embeds in a message as spoilers if it sees at least *one* URL (used for an embed or not) inside a spoiler tag, so it's not necessary to check for the specific embed URL.