### PR TITLE
feat: Allow the image API server to send image outputs directly

### DIFF
--- a/api/IMPLEMENTATION.md
+++ b/api/IMPLEMENTATION.md
@@ -1,5 +1,5 @@
 # esmBot Image API
-The esmBot image API is a combined HTTP and WebSocket API. The default port to access the API is 3762. The API supports very basic authentication, which is defined on the server via the PASS environment variable and is sent from the client via the Authentication header in both HTTP and WS requests.
+The esmBot image API is a combined HTTP and WebSocket API. The default port to access the API is 3762. The API supports very basic authentication, which is defined on the server via the `PASS` environment variable and is sent from the client via the Authentication header in both HTTP and WS requests.
 
 ## HTTP
 
@@ -20,6 +20,7 @@ A client sends *requests* (T-messages) to a server, which subsequently *replies*
 - Twait 0x06
 - Rwait 0x07
 - Rinit 0x08
+- Rsent 0x09
 
 ### Messages
 [n] means n bytes.
@@ -34,18 +35,30 @@ A client sends *requests* (T-messages) to a server, which subsequently *replies*
 - Twait tag[2] jid[8]
 - Rwait tag[2]
 - Rinit tag[2] max_jobs[2] running_jobs[2] formats[j]
+- Rsent tag[2]
 
 ### Job Object
 The job object is formatted like this:
 ```js
 {
-  "cmd": string,      // name of internal image command, e.g. caption
-  "path": string,     // canonical image URL, used for getting the actual image
-  "url": string,      // original image URL, used for message filtering
-  "params": {         // content varies depending on the command, some common parameters are listed here
-    "type": string,   // mime type of output, should usually be the same as input
+  "cmd": string,       // name of internal image command, e.g. caption
+  "path": string,      // canonical image URL, used for getting the actual image
+  "url": string,       // original image URL, used for message filtering
+  "params": {          // content varies depending on the command, some common parameters are listed here
+    "type": string,    // mime type of output, should usually be the same as input
+    "togif": boolean,  // convert output to gif
     ...
   },
-  "name": string      // filename of the image, without extension
+  "name": string,      // filename of the image, without extension
+  "ephemeral": string, // whether to post the output as an ephemeral message (only when responding directly, see below section)
+  "spoiler": string    // whether to post the output as a spoiler (only when responding directly, see below section)
 }
 ```
+
+### Direct Posting
+The image API will attempt to respond to a command by itself if all of the following criteria is met:
+- The original request was done through an interaction/slash command
+- The bot's application/user ID is specified on the API server through the `CLIENT_ID` environment variable
+- The incoming job object has an interaction token set in the job object with the key `token`
+- The output data is a PNG, JPEG, GIF, or WEBP
+- The output data is less than 25 MB

--- a/classes/imageCommand.js
+++ b/classes/imageCommand.js
@@ -95,8 +95,15 @@ class ImageCommand extends Command {
       status = await this.processMessage(this.message.channel ?? await this.client.rest.channels.get(this.message.channelID));
     }
 
+    if (this.interaction) {
+      imageParams.ephemeral = this.options.ephemeral;
+      imageParams.spoiler = needsSpoiler;
+      imageParams.token = this.interaction.token;
+    }
+
     try {
       const { buffer, type } = await runImageJob(imageParams);
+      if (type === "sent") return;
       if (type === "ratelimit") return "I've been ratelimited by the server hosting that image. Try uploading your image somewhere else.";
       if (type === "nocmd") return "That command isn't supported on this instance of esmBot.";
       if (type === "nogif" && this.constructor.requiresGIF) return "That isn't a GIF!";

--- a/utils/imageConnection.js
+++ b/utils/imageConnection.js
@@ -10,6 +10,7 @@ const Tcancel = 0x04;
 const Twait = 0x06;
 //const Rwait = 0x07;
 const Rinit = 0x08;
+const Rsent = 0x09;
 
 class ImageConnection {
   constructor(host, auth, tls = false) {
@@ -62,7 +63,11 @@ class ImageConnection {
       promise.reject(new Error(msg.slice(3, msg.length).toString()));
       return;
     }
-    promise.resolve();
+    if (op === Rsent) {
+      promise.resolve(true);
+    } else {
+      promise.resolve();
+    }
   }
 
   onError(e) {


### PR DESCRIPTION
As it stands, the current implementation of image handling on the network side is somewhat inefficient. I've set a new goal to improve performance and security in this area.

This change serves as a first step towards this goal. It allows the image API server to send output image data directly to Discord without having to send it back to the bot first, under the following conditions:
- The original request was done through an interaction/slash command
- The bot's application/user ID is specified on the API server through the `CLIENT_ID` environment variable
- The incoming job object has an interaction token set in the job object with the key `token`
- The output data is a PNG, JPEG, GIF, or WEBP
- The output data is less than 25 MB

This should provide a large reduction in network bandwidth usage for interactions due to only having to transfer the final image data over the network once. For security purposes, classic commands will not be supported with this method due to them requiring a persistent bot token on every image API server.