### PR TITLE
perf: remove unecessary copy in image-runner.js

### DIFF
--- a/utils/image-runner.js
+++ b/utils/image-runner.js
@@ -78,7 +78,7 @@ export default function run(object) {
 if (!isMainThread) {
   run(workerData)
     .then(returnObject => {
-      parentPort.postMessage(returnObject);
+      parentPort.postMessage(returnObject, [returnObject.buffer.buffer]);
     })
     .catch(err => {
       // turn promise rejection into normal error


### PR DESCRIPTION
worker_threads can share memory, so move the underlying ArrayBuffer instead of copying it.
NAPI has an external buffer feature that also lets us move command output directly to js without copying it.
This PR removes the unnecessary overhead.
