### PR TITLE
Check the input to qrcreate

### DIFF
--- a/commands/general/qrcreate.js
+++ b/commands/general/qrcreate.js
@@ -2,18 +2,18 @@ import ImageCommand from "../../classes/imageCommand.js";
 import { cleanMessage } from "../../utils/misc.js";
 
 class QrCreateCommand extends ImageCommand {
-  params() {
-    const cleanedMessage = cleanMessage(this.message ?? this.interaction, this.options.text ?? this.args.join(" "));
-    return {
-      text: cleanedMessage
-    };
-  }
-
   async criteria(text, _url) {
     if (QrCreateCommand.textEncoder.encode(text).length > QrCreateCommand.maxBytes) {
       return false;
     }
     return true;
+  }
+
+  params() {
+    const cleanedMessage = cleanMessage(this.message ?? this.interaction, this.options.text ?? this.args.join(" "));
+    return {
+      text: cleanedMessage
+    };
   }
 
   static init() {

--- a/commands/general/qrcreate.js
+++ b/commands/general/qrcreate.js
@@ -3,6 +3,10 @@ import { cleanMessage } from "../../utils/misc.js";
 
 class QrCreateCommand extends ImageCommand {
   async criteria(text, _url) {
+    // assuming a character uses at most 4 bytes
+    if (text.length < QrCreateCommand.maxBytes / 4) {
+      return true;
+    }
     if (QrCreateCommand.textEncoder.encode(text).length > QrCreateCommand.maxBytes) {
       return false;
     }

--- a/commands/general/qrcreate.js
+++ b/commands/general/qrcreate.js
@@ -9,12 +9,28 @@ class QrCreateCommand extends ImageCommand {
     };
   }
 
+  async criteria(text, _url) {
+    if (QrCreateCommand.textEncoder.encode(text).length > QrCreateCommand.maxBytes) {
+      return false;
+    }
+    return true;
+  }
+
+  static init() {
+    super.init();
+    this.flags.find((v) => v.name === "text").maxLength = QrCreateCommand.maxBytes;
+    return this;
+  }
+
   static description = "Generates a QR code";
 
   static requiresImage = false;
   static requiresText = true;
   static noText = "You need to provide some text to generate a QR code!";
   static command = "qrcreate";
+
+  static textEncoder = new TextEncoder();
+  static maxBytes = 2952;     // a QR code can only encode up to 2953 bytes
 }
 
 export default QrCreateCommand;

--- a/commands/general/qrcreate.js
+++ b/commands/general/qrcreate.js
@@ -26,7 +26,7 @@ class QrCreateCommand extends ImageCommand {
 
   static requiresImage = false;
   static requiresText = true;
-  static noText = "You need to provide some text to generate a QR code!";
+  static noText = "You need to provide some text that is less than 2953 bytes to generate a QR code!";
   static command = "qrcreate";
 
   static textEncoder = new TextEncoder();

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -625,7 +625,7 @@
     "noText": {
       "homebrew": "You need to provide some text to make a Homebrew Channel edit!",
       "sonic": "You need to provide some text to make a Sonic meme!",
-      "qrcreate": "You need to provide some text to generate a QR code!",
+      "qrcreate": "You need to provide some text that is less than 2953 bytes to generate a QR code!",
       "caption": "You need to provide some text to add a caption!",
       "caption2": "You need to provide some text to add a caption!",
       "flag": "You need to provide an emoji of a flag to overlay!",


### PR DESCRIPTION
Ensures that the input text is less than 2953 bytes before attempting to create a QR code from it, since a QR code can only encode up to 2953 bytes.