### PR TITLE
Remove some text cleaning from base64 decode

### DIFF
--- a/commands/general/base64.js
+++ b/commands/general/base64.js
@@ -12,7 +12,7 @@ class Base64Command extends Command {
     this.success = true;
     if (command === "decode") {
       const b64Decoded = Buffer.from(string, "base64").toString("utf8");
-      return `\`\`\`\n${await clean(b64Decoded)}\`\`\``;
+      return `\`\`\`\n${b64Decoded.replaceAll("`", `\`${String.fromCharCode(8203)}`).replaceAll("@", `@${String.fromCharCode(8203)}`)}\`\`\``;
     } else if (command === "encode") {
       const b64Encoded = Buffer.from(string, "utf8").toString("base64");
       return `\`\`\`\n${b64Encoded}\`\`\``;


### PR DESCRIPTION
Attempting to address issue #479 where some base64 decodes are being excessively sanitized. In this change base64 essentially skips the optional replaces that were in the clean function. This seems to provide correct output but I am unsure if clean() is needed for security. The output still cannot exit the code block with backticks.