### PR TITLE
fix: Vague PostgreSQL migration errors

### DIFF
--- a/src/database/postgresql.ts
+++ b/src/database/postgresql.ts
@@ -97,7 +97,7 @@ export default class PostgreSQLPlugin implements DatabasePlugin {
         }
         await sql`INSERT INTO settings ${sql({ id: 1, version: latestVersion })} ON CONFLICT (id) DO UPDATE SET version = ${latestVersion}`;
       });
-    } catch (e) {
+    } catch (e: Error) {
       logger.error(`PostgreSQL migration failed: ${e.stack}`);
       logger.error("Unable to start the bot, quitting now.");
       return 1;

--- a/src/database/postgresql.ts
+++ b/src/database/postgresql.ts
@@ -98,11 +98,7 @@ export default class PostgreSQLPlugin implements DatabasePlugin {
         await sql`INSERT INTO settings ${sql({ id: 1, version: latestVersion })} ON CONFLICT (id) DO UPDATE SET version = ${latestVersion}`;
       });
     } catch (e) {
-      if (e instanceof Error) {
-        logger.error(`PostgreSQL migration failed: ${e.stack}`);
-      } else {
-        logger.error(`PostgreSQL migration failed: ${e}`);
-      }
+      logger.error(`PostgreSQL migration failed: ${(err as Error).stack || err}`);
       logger.error("Unable to start the bot, quitting now.");
       return 1;
     }

--- a/src/database/postgresql.ts
+++ b/src/database/postgresql.ts
@@ -97,7 +97,7 @@ export default class PostgreSQLPlugin implements DatabasePlugin {
         }
         await sql`INSERT INTO settings ${sql({ id: 1, version: latestVersion })} ON CONFLICT (id) DO UPDATE SET version = ${latestVersion}`;
       });
-    } catch (e) {
+    } catch (err) {
       logger.error(`PostgreSQL migration failed: ${(err as Error).stack || err}`);
       logger.error("Unable to start the bot, quitting now.");
       return 1;

--- a/src/database/postgresql.ts
+++ b/src/database/postgresql.ts
@@ -98,8 +98,7 @@ export default class PostgreSQLPlugin implements DatabasePlugin {
         await sql`INSERT INTO settings ${sql({ id: 1, version: latestVersion })} ON CONFLICT (id) DO UPDATE SET version = ${latestVersion}`;
       });
     } catch (e) {
-      logger.error(`PostgreSQL migration failed:`);
-      logger.error(`${e.stack}`);
+      logger.error(`PostgreSQL migration failed: ${e.stack}`);
       logger.error("Unable to start the bot, quitting now.");
       return 1;
     }

--- a/src/database/postgresql.ts
+++ b/src/database/postgresql.ts
@@ -97,8 +97,12 @@ export default class PostgreSQLPlugin implements DatabasePlugin {
         }
         await sql`INSERT INTO settings ${sql({ id: 1, version: latestVersion })} ON CONFLICT (id) DO UPDATE SET version = ${latestVersion}`;
       });
-    } catch (e: Error) {
-      logger.error(`PostgreSQL migration failed: ${e.stack}`);
+    } catch (e) {
+      if (e instanceof Error) {
+        logger.error(`PostgreSQL migration failed: ${e.stack}`);
+      } else {
+        logger.error(`PostgreSQL migration failed: ${e}`);
+      }
       logger.error("Unable to start the bot, quitting now.");
       return 1;
     }

--- a/src/database/postgresql.ts
+++ b/src/database/postgresql.ts
@@ -98,7 +98,8 @@ export default class PostgreSQLPlugin implements DatabasePlugin {
         await sql`INSERT INTO settings ${sql({ id: 1, version: latestVersion })} ON CONFLICT (id) DO UPDATE SET version = ${latestVersion}`;
       });
     } catch (e) {
-      logger.error(`PostgreSQL migration failed: ${e}`);
+      logger.error(`PostgreSQL migration failed:`);
+      logger.error(`${e.stack}`);
       logger.error("Unable to start the bot, quitting now.");
       return 1;
     }


### PR DESCRIPTION
esmBot gives very vague PostgreSQL errors when migrating:

<img width="418" alt="image" src="https://github.com/user-attachments/assets/9dff632c-a647-429c-bcac-9989f85858ff" />

This change logs error.stack instead as to debug easier