### PR TITLE
Added a url option for bot status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,6 @@ API_TYPE=none
 
 # Put ID of server to limit owner-only commands to
 ADMIN_SERVER=
+
+# External JSON url for status messages (Leave blank to use default json file in config/messages.json)
+STATUS_MESSAGES=

--- a/src/classes/imageCommand.ts
+++ b/src/classes/imageCommand.ts
@@ -206,9 +206,20 @@ class ImageCommand extends Command {
     }
   }
 
-  processMessage(channel: AnyTextableChannel): Promise<Message> {
+  async processMessage(channel: AnyTextableChannel): Promise<Message> {
+   const url = process.env.STATUS_MESSAGES;
+   var emotes;
+
+   if (!url || url.trim() === '') {
+      emotes = messages.emotes;
+    } else {
+      const res = await fetch(url);
+      const json: any = await res.json();
+      emotes = json.emotes;
+    }
+
     return channel.createMessage({
-      content: `${random(messages.emotes) || "⚙️"} ${this.getString("image.processing")}`,
+      content: `${random(emotes) || "⚙️"} ${this.getString("image.processing")}`,
     });
   }
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -62,7 +62,7 @@ export async function activityChanger(bot: Client) {
     await bot.editStatus("dnd", [
       {
         type: 0,
-        name: random(messagesConfig.messages) + (commandsConfig.types.classic ? ` | @${bot.user.username} help` : ""),
+        name: random(await getNewBotStatus() || messagesConfig.messages) + (commandsConfig.types.classic ? ` | @${bot.user.username} help` : ""),
       },
     ]);
   }
@@ -89,11 +89,11 @@ export function startBroadcast(bot: Client, message: string) {
   broadcast = true;
 }
 
-export function endBroadcast(bot: Client) {
+export async function endBroadcast(bot: Client) {
   bot.editStatus("dnd", [
     {
       type: 0,
-      name: random(messagesConfig.messages) + (commandsConfig.types.classic ? ` | @${bot.user.username} help` : ""),
+      name: random(await getNewBotStatus() || messagesConfig.messages) + (commandsConfig.types.classic ? ` | @${bot.user.username} help` : ""),
     },
   ]);
   broadcast = false;
@@ -224,4 +224,16 @@ export function safeBigInt(input: string | number | bigint | boolean) {
   } catch {
     return -1;
   }
+}
+
+export async function getNewBotStatus() {
+  const url = process.env.STATUS_MESSAGES;
+
+  if (!url || url.trim() === '') {
+    return messagesConfig.messages;
+  }
+
+  const res = await fetch(url);
+  const json: any = await res.json();
+  return json.messages;
 }


### PR DESCRIPTION
This commit adds a new vartiable to the env file to put in a URL instead of using the bots default `messages.json`.
Useful for self hosted/private instances.