### PR TITLE
fix: only mirror repo canonical to codeberg

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   sync-repo-to-codeberg:
+    if: github.repository == 'esmBot/esmBot'
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Only run the mirror workflow on esmBot/esmBot. Without this line, the mirror workflow attempts (and fails) to mirror forks.

See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-only-run-job-for-specific-repository