### PR TITLE
feat: port wall command to libvips

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ set(SOURCE_FILES natives/blur.cc
   natives/uncanny.cc
   natives/uncaption.cc
   natives/watermark.cc
-  natives/whisper.cc)
+  natives/whisper.cc
+  natives/wall.cc)
 
 if (APPLE)
   set(WITH_ZXING_DEFAULT OFF)
@@ -54,13 +55,12 @@ else()
   set(WITH_ZXING_DEFAULT ON)
 endif()
 
-option(WITH_MAGICK "Build with ImageMagick, enables the magik and wall commands" OFF)
+option(WITH_MAGICK "Build with ImageMagick, enables the magik command" OFF)
 option(WITH_ZXING "Build with zxing-cpp, enables the qr command" ${WITH_ZXING_DEFAULT})
 option(WITH_BACKWARD "Build with backward-cpp, prints a backtrace on crash/abort" ON)
 
 if (WITH_MAGICK)
-  list(APPEND SOURCE_FILES natives/magik.cc
-    natives/wall.cc)
+  list(APPEND SOURCE_FILES natives/magik.cc)
 endif()
 
 if (WITH_ZXING)

--- a/natives/commands.h
+++ b/natives/commands.h
@@ -50,9 +50,7 @@ declare_input_func(Tile);
 declare_input_func(ToGif);
 declare_input_func(Uncanny);
 declare_input_func(Uncaption);
-#if MAGICK_ENABLED
 declare_input_func(Wall);
-#endif
 declare_input_func(Watermark);
 declare_input_func(Whisper);
 

--- a/natives/common.h
+++ b/natives/common.h
@@ -98,9 +98,7 @@ const std::map<std::string, ArgumentMap (*)(const string &type, string &outType,
     {"togif",      &ToGif     },
     {"uncanny",    &Uncanny   },
     {"uncaption",  &Uncaption },
-#if MAGICK_ENABLED
     {"wall",       &Wall      },
-#endif
     {"watermark",  &Watermark },
     {"whisper",    &Whisper   }
 };

--- a/natives/wall.cc
+++ b/natives/wall.cc
@@ -1,64 +1,75 @@
-#ifdef MAGICK_ENABLED
-#include <Magick++.h>
-
-#include <cstring>
-#include <iostream>
-#include <list>
+#include <vips/vips8>
 
 #include "common.h"
 
 using namespace std;
-using namespace Magick;
+using namespace vips;
 
-ArgumentMap Wall([[maybe_unused]] const string &type, string &outType, const char *bufferdata, size_t bufferLength,
-                 [[maybe_unused]] ArgumentMap arguments, [[maybe_unused]] bool *shouldKill) {
-  Blob blob;
+ArgumentMap Wall(const string &type, string &outType, const char *bufferdata, size_t bufferLength,
+                  [[maybe_unused]] ArgumentMap arguments, bool *shouldKill) {
+  VImage in = VImage::new_from_buffer(bufferdata, bufferLength, "", GetInputOptions(type, false, false));
+  if (!in.has_alpha()) in = in.bandjoin(255);
 
-  list<Image> frames;
-  list<Image> coalesced;
-  list<Image> mid;
+  int pageHeight = vips_image_get_page_height(in.get_image());
+  int nPages = type == "avif" ? 1 : vips_image_get_n_pages(in.get_image());
+  int width = in.width();
+
   try {
-    readImages(&frames, Blob(bufferdata, bufferLength));
-  } catch (Magick::WarningCoder &warning) {
-    cerr << "Coder Warning: " << warning.what() << endl;
-  } catch (Magick::Warning &warning) {
-    cerr << "Warning: " << warning.what() << endl;
-  }
-  coalesceImages(&coalesced, frames.begin(), frames.end());
-
-  for (Image &image : coalesced) {
-    image.resize(Geometry("128x128"));
-    image.virtualPixelMethod(Magick::TileVirtualPixelMethod);
-    image.matteColor("none");
-    image.backgroundColor("none");
-    image.scale(Geometry("512x512"));
-    double arguments[16] = {0, 0, 57, 42, 0, 128, 63, 130, 128, 0, 140, 60, 128, 128, 140, 140};
-    image.distort(Magick::PerspectiveDistortion, 16, arguments);
-    image.scale(Geometry("800x800>"));
-    image.magick(outType);
-    mid.push_back(image);
-  }
-
-  optimizeTransparency(mid.begin(), mid.end());
-
-  if (outType == "gif") {
-    for (Image &image : mid) {
-      image.quantizeDitherMethod(FloydSteinbergDitherMethod);
-      image.quantize();
+    in = NormalizeVips(in, &width, &pageHeight, nPages);
+  } catch (int e) {
+    if (e == -1) {
+      ArgumentMap output;
+      output["buf"] = "";
+      outType = "frames";
+      return output;
     }
   }
 
-  writeImages(mid.begin(), mid.end(), &blob);
+  // We fit one tile inside a 128x128 box in order to 
+  // reduce resolution, then blow it up to 512x512
+  double maxSize = std::max(width, pageHeight);
+  VImage tile = in.resize(128.0 / maxSize);
+  tile = tile.resize(512.0 / 128.0).copy_memory();
+  int newHeight = vips_image_get_page_height(tile.get_image());
+  width = tile.width();
+  pageHeight = nPages > 1 ? newHeight / nPages : newHeight;
 
-  size_t dataSize = blob.length();
+  // This distortion matrix was computed with `getPerspectiveTransform`
+  // from OpenCV, with the original ImageMagick set of points:
+  // {0, 0, 57, 42, 0, 128, 63, 130, 128, 0, 140, 60, 128, 128, 140, 140}
+  double T[] = {
+    1.32996610e+00, -9.06795066e-02, -7.19995282e+01,
+    -2.75152214e-01,  1.26875743e+00, -3.76041359e+01,
+    -7.70327830e-04, -7.08433645e-04
+  };
+  VImage i = VImage::xyz(512, 512);
 
-  char *data = reinterpret_cast<char *>(malloc(dataSize));
-  memcpy(data, blob.data(), dataSize);
+  VImage xi = (i[0] * T[0] + i[1] * T[1] + T[2]) / (i[0] * T[6] + i[1] * T[7] + 1);
+  VImage yi = (i[0] * T[3] + i[1] * T[4] + T[5]) / (i[0] * T[6] + i[1] * T[7] + 1);
+  xi = xi % width;
+  yi = yi % pageHeight;
+  VImage index = xi.bandjoin(yi).copy_memory();
+
+  vector<VImage> img;
+  for (int i = 0; i < nPages; i++) {
+    VImage img_frame = nPages > 1 ? tile.crop(0, i * pageHeight, width, pageHeight) : tile;
+    // The 'extend' here doesn't do the tiling, it just fixes
+    // a weird border that forms around each tile. 
+    VImage frame = img_frame.mapim(index, VImage::option()->set("extend", VIPS_EXTEND_REPEAT)); 
+    img.push_back(frame);
+  }
+  VImage final = VImage::arrayjoin(img, VImage::option()->set("across", 1));
+  final.set(VIPS_META_PAGE_HEIGHT, 512);
+
+  SetupTimeoutCallback(final, shouldKill);
+
+  char *buf;
+  size_t dataSize = 0;
+  final.write_to_buffer(("." + outType).c_str(), reinterpret_cast<void **>(&buf), &dataSize);
 
   ArgumentMap output;
-  output["buf"] = data;
+  output["buf"] = buf;
   output["size"] = dataSize;
 
   return output;
 }
-#endif


### PR DESCRIPTION
This pull request ports the wall command over to libvips away from ImageMagick. The functionality of the command should stay the same, except that the output now is always 512x512, whereas the output used to have the input images aspect ratio and fit a 512x512 box. If this functionality is required, then it shouldn't be too hard to implement!

The perspective distortion was adapted from [here](https://github.com/libvips/libvips/discussions/3140).