### PR TITLE
docs: Fix trivializing language and vague link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ esmBot is a free and open-source Discord bot designed to entertain your server. 
 
 You can invite the main instance of esmBot to your server using this link: https://esmbot.net/invite
 
-A command list can be found [here](https://esmbot.net/help.html).
+You can browse the full [command list](https://esmbot.net/help.html) on the website.
 
-If you want to self-host the bot, a guide can be found [here](https://docs.esmbot.net/setup).
+If you want to self-host the bot, follow the [self-hosting guide](https://docs.esmbot.net/setup).
 
 ## Contributing
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,7 +9,7 @@ To make managing environment variables easier, an example `.env` file is include
 ### Required
 
 - `NODE_ENV`: Used for tuning the bot to different environments. If you don't know what to set it to, leave it as is.
-- `TOKEN`: Your bot's token. You can find this [here](https://discord.com/developers/applications) under your application's Bot tab.
+- `TOKEN`: Your bot's token. You can find this in the [Discord developer portal](https://discord.com/developers/applications) under your application's Bot tab.
 - `DB`: The database connection string. By default the `sqlite` and `postgresql` protocols are available, but this can be expanded by putting proper DB driver scripts into `utils/database/`.
 - `OWNER`: Your Discord user ID. This is used for granting yourself access to certain management commands. Adding multiple users is supported by separating the IDs with a comma; however, this is not recommended for security purposes.
 - `PREFIX`: The bot's default command prefix for classic commands. Note that servers can set their own individual prefixes via the `prefix` command.

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -1,6 +1,6 @@
 # Custom Commands
 
-esmBot has a powerful and flexible command handler, allowing you to create new commands and categories simply by creating new files. This page will provide a reference for creating new commands.
+esmBot has a powerful and flexible command handler, allowing you to create new commands and categories by creating new files. This page will provide a reference for creating new commands.
 
 ## Directory Structure
 
@@ -21,7 +21,7 @@ commands/
     > ...
 ```
 
-As you can see, each command is grouped into categories, which are represented by subdirectories. To create a new category, you can simply create a new directory inside of the `commands` directory, and to create a new command, you can create a new JS file under one of those subdirectories.
+As you can see, each command is grouped into categories, which are represented by subdirectories. To create a new category, you can create a new directory inside of the `commands` directory, and to create a new command, you can create a new JS file under one of those subdirectories.
 
 !!! tip
 
@@ -29,7 +29,7 @@ As you can see, each command is grouped into categories, which are represented b
 
 !!! tip
 
-    When using Node.js v23.6.0 or above, Node.js v22.6.0 or above with the `--experimental-strip-types` flag enabled, or Deno, it is possible to create commands using TypeScript instead of JavaScript. To do so, simply create a file with a `.ts` extension instead of `.js`; the command will be loaded and handled at runtime as if it were a regular JavaScript command.
+    When using Node.js v23.6.0 or above, Node.js v22.6.0 or above with the `--experimental-strip-types` flag enabled, or Deno, it is possible to create commands using TypeScript instead of JavaScript. To do so, create a file with a `.ts` extension instead of `.js`; the command will be loaded and handled at runtime as if it were a regular JavaScript command.
 
 ## Command Structure
 
@@ -52,7 +52,7 @@ export default HelloCommand;
 
 As you can see, the first thing we do is import the Command class. We then create a new class for the command that extends that class to provide the needed parameters. We then define the command function, which is named `run`. Some static parameters, including the command description and an alias for the command, `helloworld`, are also defined. Finally, once everything in the command class is defined, we export the new class to be loaded as a module by the command handler.
 
-The default command name is the same as the filename that you save it as, excluding the `.js` file extension. If you ever want to change the name of the command, just rename the file.
+The default command name is the same as the filename that you save it as, excluding the `.js` file extension. If you ever want to change the name of the command, rename the file.
 
 The parameters available to your command consist of the following:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,7 +17,7 @@ If you have any further questions regarding setup, feel free to ask in the #supp
 
 !!! tip
 
-    You can run the bot using Docker or Podman for a somewhat simpler setup experience. [Click here to go to the container setup guide.](https://docs.esmbot.net/containers)
+    You can run the bot using Docker or Podman for a somewhat simpler setup experience. See the [container setup guide](https://docs.esmbot.net/containers).
 
 ### 1. Install the required native dependencies.
 
@@ -35,7 +35,7 @@ Choose the OS you're using below for insallation instructions.
 
     These instructions apply to Fedora 38/RHEL 9 or later.
 
-    Some of these packages require that you add the RPM Fusion and/or EPEL repositories. You can find instructions on how to add them [here](https://rpmfusion.org/Configuration).
+    Some of these packages require that you add the RPM Fusion and/or EPEL repositories. You can find instructions in the [RPM Fusion configuration guide](https://rpmfusion.org/Configuration).
     ```sh
     sudo dnf install git curl cmake ffmpeg sqlite gcc-c++ ImageMagick-c++-devel vips-devel cabextract zxing-cpp-devel
     ```
@@ -104,7 +104,7 @@ esmBot officially supports two database systems: SQLite and PostgreSQL. While SQ
 
 If you would like to use the SQLite database, no configuration is needed and you can move on to the next step.
 
-If you would like to use the PostgreSQL database, view the setup instructions [here](https://docs.esmbot.net/postgresql) and come back here when you're finished.
+If you would like to use the PostgreSQL database, view the [PostgreSQL setup instructions](https://docs.esmbot.net/postgresql) and come back here when you're finished.
 
 ---
 
@@ -178,7 +178,7 @@ java -jar Lavalink.jar
 
 !!! info
 
-    You'll need to run Lavalink alongside the bot in order to use it. There are a few methods to do this, such as the `screen` command, creating a new systemd service, or simply just opening a new terminal session alongside your current one.
+    You'll need to run Lavalink alongside the bot in order to use it. There are a few methods to do this, such as the `screen` command, creating a new systemd service, or opening a new terminal session alongside your current one.
 
 ---
 
@@ -200,11 +200,11 @@ To edit this file in the terminal, run this command:
 nano .env
 ```
 
-This will launch a text editor with the file ready to go. Create a Discord application [here](https://discord.com/developers/applications) and select the Bot tab on the left, then create a bot user. Once you've done this, copy the token it gives you and put it in the `TOKEN` variable.
+This will launch a text editor with the file ready to go. Create a Discord application in the [Discord developer portal](https://discord.com/developers/applications) and select the Bot tab on the left, then create a bot user. Once you've done this, copy the token it gives you and put it in the `TOKEN` variable.
 
 When you're finished editing the file, press Ctrl + X, then Y and Enter.
 
-An overview of each of the variables in the `.env` file can be found [here](https://docs.esmbot.net/config).
+The [config reference](https://docs.esmbot.net/config) gives an overview of each of the variables in the `.env` file.
 
 ---
 
@@ -272,7 +272,7 @@ pm2 start ecosystem.config.cjs
 
 ??? faq "Gifs from Tenor and KLIPY result in a "no decode delegate for this image format" or "improper image header" error"
 
-    Tenor and KLIPY GIFs are typically delivered as videos, which libvips can't decode most of the time. This should be handled for Tenor GIFs; if this happens, it is most likely a bug and should be reported [here](https://github.com/esmBot/esmBot/issues) or in the [esmBot Support server](https://esmbot.net/support). For KLIPY, you'll need to get a KLIPY API key from [here](https://partner.klipy.com) and put it in the `KLIPY` variable in .env.
+    Tenor and KLIPY GIFs are typically delivered as videos, which libvips can't decode most of the time. This should be handled for Tenor GIFs; if this happens, it is most likely a bug and should be reported on the [issue tracker](https://github.com/esmBot/esmBot/issues) or in the [esmBot Support server](https://esmbot.net/support). For KLIPY, you'll need to get a KLIPY API key from the [KLIPY partner panel](https://partner.klipy.com) and put it in the `KLIPY` variable in .env.
 
 ---
 


### PR DESCRIPTION
Follows https://justsimply.dev/ and https://www.dont-click-here.com/